### PR TITLE
Adding %CommonAppDataFolder% to Dir.cs description

### DIFF
--- a/Source/src/WixSharp/Dir.cs
+++ b/Source/src/WixSharp/Dir.cs
@@ -47,6 +47,7 @@ namespace WixSharp
     ///  <para>%WindowsFolder% - [WindowsFolder]</para>
     ///  <para>%ProgramFiles% - [ProgramFilesFolder]</para>
     ///  <para>%ProgramMenu% - [ProgramMenuFolder]</para>
+    ///  <para>%CommonAppDataFolder% - [CommonAppDataFolder]</para>
     ///  <para>%AppDataFolder% - [AppDataFolder]</para>
     ///  <para>%CommonFilesFolder% - [CommonFilesFolder]</para>
     ///  <para>%LocalAppDataFolder% - [LocalAppDataFolder]</para>


### PR DESCRIPTION
%CommonAppDataFolder% environment variable, mapped to Wix constant [CommonAppDataFolder] was missing from the list in the class description.
It is a minor detail, but it saves you some time when you're searching for that destination.