### PR TITLE
Issue #27: Fixing AppSearch.GetProducts() crash

### DIFF
--- a/Source/src/WixSharp/AppSearch.cs
+++ b/Source/src/WixSharp/AppSearch.cs
@@ -52,13 +52,11 @@ namespace WixSharp.CommonTasks
         {
             var result = new List<string>();
 
-            var productCode = new StringBuilder();
+            var productCode = new StringBuilder(40);
 
             int i = 0;
             while (0 == MsiEnumProducts(i++, productCode))
             {
-                var productNameLen = 512;
-                var productName = new StringBuilder(productNameLen);
                 result.Add(productCode.ToString());
             }
 


### PR DESCRIPTION
The StringBuilder instance given to the MsiEnumProducts() call must have
some initialized array. The product code GUIDs returned by that call
(formatted with braces) should take 38 characters.