### PR TITLE
Added Condition-s for .NET Frameworks 4.5.1, 4.5.2, 4.6, 4.6.1 and 4.6.2

### DIFF
--- a/Source/src/WixSharp/Condition.cs
+++ b/Source/src/WixSharp/Condition.cs
@@ -195,6 +195,26 @@ namespace WixSharp
         /// </summary>
         public readonly static Condition Net45_Installed = new Condition(" (NETFRAMEWORK45 >= '#378389') ");
         /// <summary>
+        /// The .NET4.5.1 installed. This condition is to be used in Project.SetNetFxPrerequisite.
+        /// </summary>
+        public readonly static Condition Net451_Installed = new Condition(" (NETFRAMEWORK45 >= '#378675') ");
+        /// <summary>
+        /// The .NET4.5.2 installed. This condition is to be used in Project.SetNetFxPrerequisite.
+        /// </summary>
+        public readonly static Condition Net452_Installed = new Condition(" (NETFRAMEWORK45 >= '#379893') ");
+        /// <summary>
+        /// The .NET4.6 installed. This condition is to be used in Project.SetNetFxPrerequisite.
+        /// </summary>
+        public readonly static Condition Net46_Installed = new Condition(" (NETFRAMEWORK45 >= '#393295') ");
+        /// <summary>
+        /// The .NET4.6.1 installed. This condition is to be used in Project.SetNetFxPrerequisite.
+        /// </summary>
+        public readonly static Condition Net461_Installed = new Condition(" (NETFRAMEWORK45 >= '#394254') ");
+        /// <summary>
+        /// The .NET4.6.2 installed. This condition is to be used in Project.SetNetFxPrerequisite.
+        /// </summary>
+        public readonly static Condition Net462_Installed = new Condition(" (NETFRAMEWORK45 >= '#394802 ') ");
+        /// <summary>
         /// The .NET3.0 SP installed. This condition is to be used in Project.SetNetFxPrerequisite.
         /// </summary>
         public readonly static Condition Net30_SP_Installed = new Condition(" (NETFRAMEWORK30_SP_LEVEL and NOT NETFRAMEWORK30_SP_LEVEL='#0') ");


### PR DESCRIPTION
Seeing WixSharp 1.4.6.1 released today, I was wondering why there was no Wix 3.11 support.

I'm was mainly interested in the [WIX_IS_NETFRAMEWORK_462_OR_LATER_INSTALLED flag](http://stackoverflow.com/a/39900985) (described [here](http://wixtoolset.org/documentation/manual/v3/customactions/wixnetfxextension.html)), because the product I'm working on is approaching the release date.

Since there is a way to use it without depending on Wix 3.11, I took a look at [NetFx462.wxs](https://github.com/wixtoolset/wix3/blob/7c8457fa3802858add8981b92996e19574e762da/src/ext/NetFxExtension/wixlib/NetFx462.wxs) and friends, and added the missing conditions.

I've yet to test these, but since the constants were copy-pasted from [WiX sources](https://github.com/wixtoolset/wix3/blob/7c8457fa3802858add8981b92996e19574e762da/src/ext/NetFxExtension/wixlib) I'm 99.9% sure they're correct. I will test them tomorrow, but till then: Does anything speak against adding these?