### PR TITLE
fix "CustomActionRef.When" property handling in compile.

### DIFF
--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -3137,10 +3137,11 @@ namespace WixSharp
                 else if (wAction is CustomActionRef)
                 {
                     var wCustomActionRef = (CustomActionRef) wAction;
+                    var whenstr = wCustomActionRef.When == When.After ? "After" : "Before";
                     sequences.ForEach(sequence =>
                         sequence.Add(new XElement("Custom", wCustomActionRef.Condition.ToXValue(),
                             new XAttribute("Action", wCustomActionRef.Id),
-                            new XAttribute("Before", wCustomActionRef.Step))));
+                            new XAttribute(whenstr, wCustomActionRef.Step))));
 
                     product.Add(new XElement("CustomActionRef",
                         new XAttribute("Id", wCustomActionRef.Id)));

--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -3137,11 +3137,10 @@ namespace WixSharp
                 else if (wAction is CustomActionRef)
                 {
                     var wCustomActionRef = (CustomActionRef) wAction;
-                    var whenstr = wCustomActionRef.When == When.After ? "After" : "Before";
                     sequences.ForEach(sequence =>
                         sequence.Add(new XElement("Custom", wCustomActionRef.Condition.ToXValue(),
                             new XAttribute("Action", wCustomActionRef.Id),
-                            new XAttribute(whenstr, wCustomActionRef.Step))));
+                            new XAttribute(wCustomActionRef.When.ToString(), wCustomActionRef.Step))));
 
                     product.Add(new XElement("CustomActionRef",
                         new XAttribute("Id", wCustomActionRef.Id)));


### PR DESCRIPTION
WixSharp.Compiler ignored CustomActionRef.When property(always output "Before" attribute in InstallExecuteSequence/Custom)