### PR TITLE
Issue # 247 - Handling null TimeUrl

### DIFF
--- a/Source/src/WixSharp/DigitalSignature.cs
+++ b/Source/src/WixSharp/DigitalSignature.cs
@@ -61,7 +61,7 @@ namespace WixSharp
         /// <returns>Exit code of the <c>SignTool.exe</c> process.</returns>
         public virtual int Apply(string fileToSign)
         {
-            var retValue = CommonTasks.Tasks.DigitalySign(fileToSign, PfxFilePath, TimeUrl.AbsoluteUri, Password,
+            var retValue = CommonTasks.Tasks.DigitalySign(fileToSign, PfxFilePath, TimeUrl?.AbsoluteUri, Password,
                 PrepareOptionalArguments(), WellKnownLocations, UseCertificateStore);
 
             Console.WriteLine(retValue != 0

--- a/Source/src/WixSharp/DigitalSignatureBootstrapper.cs
+++ b/Source/src/WixSharp/DigitalSignatureBootstrapper.cs
@@ -14,7 +14,7 @@ namespace WixSharp
         /// <returns>Exit code of the <c>SignTool.exe</c> process.</returns>
         public override int Apply(string bootstrapperFileToSign)
         {
-            var retValue = CommonTasks.Tasks.DigitalySignBootstrapper(bootstrapperFileToSign, PfxFilePath, TimeUrl.AbsoluteUri, Password,
+            var retValue = CommonTasks.Tasks.DigitalySignBootstrapper(bootstrapperFileToSign, PfxFilePath, TimeUrl?.AbsoluteUri, Password,
                 PrepareOptionalArguments(), WellKnownLocations);
 
             Console.WriteLine(retValue != 0


### PR DESCRIPTION
Fixes #247  Passing null for timeUrl to CommonTasks.Tasks.DigitallySign when TimeUrl is null