### PR TITLE
Conditions enhancements

### DIFF
--- a/Source/src/WixSharp/Condition.cs
+++ b/Source/src/WixSharp/Condition.cs
@@ -237,6 +237,11 @@ namespace WixSharp
         public readonly static Condition Net462_Installed = new Condition(" (NETFRAMEWORK45 >= '#394802 ') ");
 
         /// <summary>
+        /// The .NET4.7 installed. This condition is to be used in Project.SetNetFxPrerequisite.
+        /// </summary>
+        public readonly static Condition Net47_Installed = new Condition(" (NETFRAMEWORK45 >= '#460798 ') ");
+
+        /// <summary>
         /// The .NET3.0 SP installed. This condition is to be used in Project.SetNetFxPrerequisite.
         /// </summary>
         public readonly static Condition Net30_SP_Installed = new Condition(" (NETFRAMEWORK30_SP_LEVEL and NOT NETFRAMEWORK30_SP_LEVEL='#0') ");

--- a/Source/src/WixSharp/Condition.cs
+++ b/Source/src/WixSharp/Condition.cs
@@ -264,6 +264,38 @@ namespace WixSharp
         /// </example>
         public static Condition Create(string value) { return new Condition(value); }
 
+        /// <summary>
+        /// Returns a new <see cref="Condition"/> performing an AND between two conditions.
+        /// </summary>
+        /// <param name="a">The first <see cref="Condition"/></param>
+        /// <param name="b">The second <see cref="Condition"/></param>
+        /// <returns>The new AND'ed condition.</returns>
+        public static Condition operator &(Condition a, Condition b)
+        {
+            return new Condition("(" + a + " AND " + b + ")");
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="Condition"/> performing an OR between two conditions.
+        /// </summary>
+        /// <param name="a">The first <see cref="Condition"/></param>
+        /// <param name="b">The second <see cref="Condition"/></param>
+        /// <returns>The new OR'ed condition.</returns>
+        public static Condition operator |(Condition a, Condition b)
+        {
+            return new Condition("(" + a + " OR " + b + ")");
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="Condition"/> adding a logical NOT before the condition.
+        /// </summary>
+        /// <param name="x">The first <see cref="Condition"/> or text</param>
+        /// <returns>The new NOT'ed condition.</returns>
+        public static Condition NOT(string x)
+        {
+            return new Condition("(NOT " + x + ")");
+        }
+
         //public Condition And(Condition condition)
         //{
         //    return Create("(" + this.ToString() + " AND " + condition.ToString() + ")");


### PR DESCRIPTION
This PR includes the following enhancements:

1. additional Net47_Installed condition (just to be complete)
2. operator overloads for & (AND), | (OR) and a static NOT operator

Last point allows for some nice readable combinations (e.g. when used in ManagedActions):
```
Condition.NOT_Installed & Condition.NOT("Upgrading")

new Condition("Upgrading") | new Condition("Uninstalling")
```
PS: not sure why the previous AND, OR, NOT local scoped methods are commented out, but I've left them intact.

I hope this PR satisfies your requirements and you'll consider them useful enough to merge them into your master.

Thanks,
Leon