### PR TITLE
Issue#251 - Passing UseCertificateStore parameter from DigitalSignatureBootstrapper

### DIFF
--- a/Source/src/WixSharp.Samples/WixSharp.xml
+++ b/Source/src/WixSharp.Samples/WixSharp.xml
@@ -348,7 +348,7 @@
         <member name="M:WixSharp.CommonTasks.Tasks.DigitalySign(System.String,System.String,System.String,System.String,System.String,System.String,System.Boolean)">
              <summary>
              Applies digital signature to a file (e.g. msi, exe, dll) with MS <c>SignTool.exe</c> utility.
-             Please use <see cref="M:WixSharp.CommonTasks.Tasks.DigitalySignBootstrapper(System.String,System.String,System.String,System.String,System.String,System.String)"/> for signing a bootstrapper.
+             Please use <see cref="M:WixSharp.CommonTasks.Tasks.DigitalySignBootstrapper(System.String,System.String,System.String,System.String,System.String,System.String,System.Boolean)"/> for signing a bootstrapper.
              </summary>
              <param name="fileToSign">The file to sign.</param>
              <param name="pfxFile">Specify the signing certificate in a file. If this file is a PFX with a password, the password may be supplied
@@ -375,7 +375,7 @@
              </code>
              </example>
         </member>
-        <member name="M:WixSharp.CommonTasks.Tasks.DigitalySignBootstrapper(System.String,System.String,System.String,System.String,System.String,System.String)">
+        <member name="M:WixSharp.CommonTasks.Tasks.DigitalySignBootstrapper(System.String,System.String,System.String,System.String,System.String,System.String,System.Boolean)">
              <summary>
              Applies digital signature to a bootstrapper and the bootstrapper engine with MS <c>SignTool.exe</c> utility.
              <a href="http://wixtoolset.org/documentation/manual/v3/overview/insignia.html">See more about bootstrapper engine signing</a>
@@ -389,6 +389,8 @@
              <param name="optionalArguments">Extra arguments to pass to the <c>SignTool.exe</c> utility.</param>
              <param name="wellKnownLocations">The optional ';' separated list of directories where SignTool.exe can be located.
              If this parameter is not specified WixSharp will try to locate the SignTool in the built-in well-known locations (system PATH)</param>
+             <param name="useCertificateStore">A flag indicating if the value of <c>pfxFile</c> is a name of the subject of the signing certificate
+             from the certificate store (as opposite to the certificate file). This value can be a substring of the entire subject name.</param>
              <returns>Exit code of the <c>SignTool.exe</c> process.</returns>
             
              <example>The following is an example of signing <c>SetupBootstrapper.exe</c> file.
@@ -402,11 +404,11 @@
              </code>
              </example>
         </member>
-        <member name="M:WixSharp.CommonTasks.Tasks.DigitalySignBootstrapperEngine(System.String,System.String,System.String,System.String,System.String,System.String)">
+        <member name="M:WixSharp.CommonTasks.Tasks.DigitalySignBootstrapperEngine(System.String,System.String,System.String,System.String,System.String,System.String,System.Boolean)">
              <summary>
              Applies digital signature to a bootstrapper engine with MS <c>SignTool.exe</c> utility.
              Note : this method doesn't sign the bootstrapper file but the engine only.
-             Please use <see cref="M:WixSharp.CommonTasks.Tasks.DigitalySignBootstrapper(System.String,System.String,System.String,System.String,System.String,System.String)"/> for signing both (bootstrapper and bootstrapper engine) instead.
+             Please use <see cref="M:WixSharp.CommonTasks.Tasks.DigitalySignBootstrapper(System.String,System.String,System.String,System.String,System.String,System.String,System.Boolean)"/> for signing both (bootstrapper and bootstrapper engine) instead.
              <a href="http://wixtoolset.org/documentation/manual/v3/overview/insignia.html">See more about Bootstrapper engine signing</a>
              </summary>
              <param name="bootstrapperFileToSign">The Bootstrapper file to sign.</param>
@@ -418,6 +420,8 @@
              <param name="optionalArguments">Extra arguments to pass to the <c>SignTool.exe</c> utility.</param>
              <param name="wellKnownLocations">The optional ';' separated list of directories where SignTool.exe can be located.
              If this parameter is not specified WixSharp will try to locate the SignTool in the built-in well-known locations (system PATH)</param>
+             <param name="useCertificateStore">A flag indicating if the value of <c>pfxFile</c> is a name of the subject of the signing certificate
+             from the certificate store (as opposite to the certificate file). This value can be a substring of the entire subject name.</param>
              <returns>Exit code of the <c>SignTool.exe</c> process.</returns>
             
              <example>The following is an example of signing <c>SetupBootstrapper.exe</c> file engine.
@@ -967,6 +971,21 @@
             <param name="entity">The entity.</param>
             <returns></returns>
         </member>
+        <member name="M:WixSharp.CommonTasks.Tasks.InstallService(System.String,System.Boolean,System.String,System.String)">
+            <summary>
+            Installs the windows service. It uses InstallUtil.exe to complete the actual installation/uninstallation.
+            During the run for the InstallUtil.exe console window is hidden.
+            If any error occurred the console output is captured and embedded into the raised Exception object.
+            </summary>
+            <remarks>In order for username/password to be accepted, the ServiceProcessInstaller.Account in the target
+            service must be set to ServiceAccount.User</remarks>
+            <param name="serviceFile">The service file.</param>
+            <param name="isInstalling">if set to <c>true</c> [is installing].</param>
+            <param name="username">The required service username.</param>
+            <param name="password">The required service password.</param>
+            <exception cref="T:System.Exception"></exception>
+            <returns>console output</returns>
+        </member>
         <member name="M:WixSharp.CommonTasks.Tasks.InstallService(System.String,System.Boolean,System.String)">
             <summary>
             Installs the windows service. It uses InstallUtil.exe to complete the actual installation/uninstallation.
@@ -977,7 +996,7 @@
             <param name="isInstalling">if set to <c>true</c> [is installing].</param>
             <param name="args">The additional InstallUtil.exe arguments.</param>
             <exception cref="T:System.Exception"></exception>
-            <returns></returns>
+            <returns>console output</returns>
         </member>
         <member name="M:WixSharp.CommonTasks.Tasks.StartService(System.String,System.Boolean)">
             <summary>

--- a/Source/src/WixSharp/CommonTasks.cs
+++ b/Source/src/WixSharp/CommonTasks.cs
@@ -223,6 +223,8 @@ namespace WixSharp.CommonTasks
         /// <param name="optionalArguments">Extra arguments to pass to the <c>SignTool.exe</c> utility.</param>
         /// <param name="wellKnownLocations">The optional ';' separated list of directories where SignTool.exe can be located.
         /// If this parameter is not specified WixSharp will try to locate the SignTool in the built-in well-known locations (system PATH)</param>
+        /// <param name="useCertificateStore">A flag indicating if the value of <c>pfxFile</c> is a name of the subject of the signing certificate
+        /// from the certificate store (as opposite to the certificate file). This value can be a substring of the entire subject name.</param>
         /// <returns>Exit code of the <c>SignTool.exe</c> process.</returns>
         ///
         /// <example>The following is an example of signing <c>SetupBootstrapper.exe</c> file.
@@ -236,13 +238,13 @@ namespace WixSharp.CommonTasks
         /// </code>
         /// </example>
         static public int DigitalySignBootstrapper(string bootstrapperFileToSign, string pfxFile, string timeURL, string password,
-            string optionalArguments = null, string wellKnownLocations = null)
+            string optionalArguments = null, string wellKnownLocations = null, bool useCertificateStore = false)
         {
-            var retval = DigitalySignBootstrapperEngine(bootstrapperFileToSign, pfxFile, timeURL, password, optionalArguments, wellKnownLocations);
+            var retval = DigitalySignBootstrapperEngine(bootstrapperFileToSign, pfxFile, timeURL, password, optionalArguments, wellKnownLocations, useCertificateStore);
             if (retval != 0)
                 return retval;
 
-            return DigitalySign(bootstrapperFileToSign, pfxFile, timeURL, password, optionalArguments, wellKnownLocations);
+            return DigitalySign(bootstrapperFileToSign, pfxFile, timeURL, password, optionalArguments, wellKnownLocations, useCertificateStore);
         }
 
         /// <summary>
@@ -260,6 +262,8 @@ namespace WixSharp.CommonTasks
         /// <param name="optionalArguments">Extra arguments to pass to the <c>SignTool.exe</c> utility.</param>
         /// <param name="wellKnownLocations">The optional ';' separated list of directories where SignTool.exe can be located.
         /// If this parameter is not specified WixSharp will try to locate the SignTool in the built-in well-known locations (system PATH)</param>
+        /// <param name="useCertificateStore">A flag indicating if the value of <c>pfxFile</c> is a name of the subject of the signing certificate
+        /// from the certificate store (as opposite to the certificate file). This value can be a substring of the entire subject name.</param>
         /// <returns>Exit code of the <c>SignTool.exe</c> process.</returns>
         ///
         /// <example>The following is an example of signing <c>SetupBootstrapper.exe</c> file engine.
@@ -273,7 +277,7 @@ namespace WixSharp.CommonTasks
         /// </code>
         /// </example>
         static public int DigitalySignBootstrapperEngine(string bootstrapperFileToSign, string pfxFile, string timeURL, string password,
-            string optionalArguments = null, string wellKnownLocations = null)
+            string optionalArguments = null, string wellKnownLocations = null, bool useCertificateStore = false)
         {
             var insigniaPath = IO.Path.Combine(Compiler.WixLocation, "insignia.exe");
             string enginePath = IO.Path.GetTempFileName();
@@ -290,7 +294,7 @@ namespace WixSharp.CommonTasks
                 if (retval != 0)
                     return retval;
 
-                retval = DigitalySign(enginePath, pfxFile, timeURL, password, optionalArguments, wellKnownLocations);
+                retval = DigitalySign(enginePath, pfxFile, timeURL, password, optionalArguments, wellKnownLocations, useCertificateStore);
                 if (retval != 0)
                     return retval;
 

--- a/Source/src/WixSharp/DigitalSignatureBootstrapper.cs
+++ b/Source/src/WixSharp/DigitalSignatureBootstrapper.cs
@@ -15,7 +15,7 @@ namespace WixSharp
         public override int Apply(string bootstrapperFileToSign)
         {
             var retValue = CommonTasks.Tasks.DigitalySignBootstrapper(bootstrapperFileToSign, PfxFilePath, TimeUrl.AbsoluteUri, Password,
-                PrepareOptionalArguments(), WellKnownLocations);
+                PrepareOptionalArguments(), WellKnownLocations, UseCertificateStore);
 
             Console.WriteLine(retValue != 0
                 ? $"Could not sign the {bootstrapperFileToSign} Bootstrapper file."


### PR DESCRIPTION
Fixes #251 Passing UseCertificateStore parameter from DigitalSignatureBootstrapper through to DigitallySign