### PR TITLE
added StartupFolder to list of user profile folders

### DIFF
--- a/Source/src/WixSharp/AutoElements.cs
+++ b/Source/src/WixSharp/AutoElements.cs
@@ -305,7 +305,8 @@ namespace WixSharp
                         "LocalAppDataFolder",
                         "TempFolder",
                         "PersonalFolder",
-                        "DesktopFolder"
+                        "DesktopFolder",
+                        "StartupFolder"
                     };
         }
 


### PR DESCRIPTION
Using the "%StartupFolder%" constant caused the below exception. Looks like it just needs to be added to the list of user profile folders.

> Component StartupFolder.EmptyDirectory installs to user profile. It must use a registry key under HKCU as its KeyPath, not a file.