### PR TITLE
Issue#247 - Fixing incorrect merge conflict resolution

### DIFF
--- a/Source/src/WixSharp/DigitalSignatureBootstrapper.cs
+++ b/Source/src/WixSharp/DigitalSignatureBootstrapper.cs
@@ -14,7 +14,7 @@ namespace WixSharp
         /// <returns>Exit code of the <c>SignTool.exe</c> process.</returns>
         public override int Apply(string bootstrapperFileToSign)
         {
-            var retValue = CommonTasks.Tasks.DigitalySignBootstrapper(bootstrapperFileToSign, PfxFilePath, TimeUrl.AbsoluteUri, Password,
+            var retValue = CommonTasks.Tasks.DigitalySignBootstrapper(bootstrapperFileToSign, PfxFilePath, TimeUrl?.AbsoluteUri, Password,
                 PrepareOptionalArguments(), WellKnownLocations, UseCertificateStore);
             Console.WriteLine(retValue != 0
                 ? $"Could not sign the {bootstrapperFileToSign} Bootstrapper file."


### PR DESCRIPTION
#247 Handling null TimeUrl so that /tr /td can be used as optional parameters without setting TimeUrl