### PR TITLE
In x64 projects, only add Win64=yes to components that haven't alread…

### DIFF
--- a/Source/src/WixSharp/AutoElements.cs
+++ b/Source/src/WixSharp/AutoElements.cs
@@ -379,8 +379,8 @@ namespace WixSharp
                 doc.Descendants("Component")
                    .ForEach(comp =>
                    {
-                       //components may already have explicitly set platform attribute (e.g. RegValue.Win64)
-                       comp.SetAttributeValue("Win64", "yes");
+                       if (!comp.HasAttribute("Win64"))
+                           comp.SetAttributeValue("Win64", "yes");
                    });
             }
         }


### PR DESCRIPTION
…y explicitly specified this attribute. Fixes #295