### PR TITLE
Localize Feature's description text (ManagedUI)

### DIFF
--- a/Source/src/WixSharp.UI/ManagedUI/Forms/FeaturesDialog.Designer.cs
+++ b/Source/src/WixSharp.UI/ManagedUI/Forms/FeaturesDialog.Designer.cs
@@ -106,6 +106,7 @@ namespace WixSharp.UI.Forms
             // 
             // label3
             // 
+            this.label3.AutoEllipsis = true;
             this.label3.AutoSize = true;
             this.label3.BackColor = System.Drawing.Color.Transparent;
             this.label3.Location = new System.Drawing.Point(17, 6);

--- a/Source/src/WixSharp.UI/ManagedUI/Forms/FeaturesDialog.cs
+++ b/Source/src/WixSharp.UI/ManagedUI/Forms/FeaturesDialog.cs
@@ -191,7 +191,7 @@ namespace WixSharp.UI.Forms
 
         void featuresTree_AfterSelect(object sender, TreeViewEventArgs e)
         {
-            description.Text = e.Node.FeatureItem().Description;
+            description.Text = e.Node.FeatureItem().Description.LocalizeWith(MsiRuntime.Localize);
         }
 
         bool isAutoCheckingActive = false;


### PR DESCRIPTION
This PR adds the following to the FeaturesDialog (ManagedUI):
1. AutoEllipsis on the label - some language have a really long (default) localization from Wix and it is truncated at the end of the screen
2. Use standard Wix# localization for the Feature's description text - i.e. now you can use "[LocId]" to retrieve appropriate localization text (at runtime) without having to use any .resx files (just like Wix# does for all the other ManagedUI Controls).

Hope this PR satisfies your requirements and you'll consider merging this in.

Thanks in advance