### PR TITLE
Updated logic to find wixsharp.wix.bin package.  Package is now first to find.

### DIFF
--- a/Source/NuGet/WixSharp/WixSharp.wix.bin.nuspec
+++ b/Source/NuGet/WixSharp/WixSharp.wix.bin.nuspec
@@ -21,6 +21,7 @@ WiX - Copyright (C) .NET Foundation and contributors</copyright>
         <tags>C# scripting msi install setup wix</tags>
     </metadata>
     <files>
+        <file src="build\Wixsharp.wix.bin.targets" target="build\Wixsharp.wix.bin.targets" />
         <file src="..\..\src\WixSharp.Samples\Wix_bin\bin\x86\burn.exe" target="tools\bin\x86\burn.exe" />
         <file src="..\..\src\WixSharp.Samples\Wix_bin\bin\candle.exe" target="tools\bin\candle.exe" />
         <file src="..\..\src\WixSharp.Samples\Wix_bin\bin\candle.exe.config" target="tools\bin\candle.exe.config" />

--- a/Source/NuGet/WixSharp/build/WixSharp.targets
+++ b/Source/NuGet/WixSharp/build/WixSharp.targets
@@ -3,6 +3,6 @@
   <Target Name="MSIAuthoring" AfterTargets="AfterBuild">
     <Message Importance="high" Text="Building MSI" />
     <!-- <SetEnvVar Values="ProjectName=$(ProjectName);ProjectDir=$(ProjectDir);SolutionName=$(SolutionName);SolutionDir=$(SolutionDir)"/> -->
-    <Exec Command="&quot;$(TargetPath)&quot; &quot;/MSBUILD:$(ProjectName)&quot;" WorkingDirectory="$(ProjectDir)"/>
+    <Exec Command="&quot;$(TargetPath)&quot; &quot;/MSBUILD:$(ProjectName)&quot; &quot;/WIXBIN:$(WixBinPackage)&quot;" WorkingDirectory="$(ProjectDir)"/>
   </Target>
 </Project>

--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -37,6 +37,7 @@ using System.Threading;
 using System.Xml.Linq;
 using Microsoft.Deployment.WindowsInstaller;
 using WixSharp.CommonTasks;
+using WixSharp.Utilities;
 using IO = System.IO;
 
 //WIX References:
@@ -272,91 +273,20 @@ namespace WixSharp
             EnsureVSIntegration();
         }
 
-        static string FindWixBinPackage(string projectFile)
-        {
-            string probePackages(string packagesRoot, bool isGlobalPackage)
-            {
-                if (IO.Directory.Exists(packagesRoot))
-                {
-                    //search for the highest version of the WiX SDK version
-                    string maxVersionPackage = null;
-                    if (!isGlobalPackage)
-                    {
-                        var packages = IO.Directory.GetDirectories(packagesRoot, "WixSharp.wix.bin.*")
-                                                   .Select(d => new
-                                                   {
-                                                       Path = d,
-                                                       Version = d.PathGetFileName().Replace("WixSharp.wix.bin.", "").ToRawVersion()
-                                                   })
-                                                   .Where(x => x.Version != null)
-                                                   .OrderBy(x => x.Version);
-
-                        maxVersionPackage = packages.LastOrDefault()?.Path;
-                    }
-                    else
-                    {
-                        var packageDir = packagesRoot.PathCombine("WixSharp.wix.bin");
-                        var packages = IO.Directory.GetDirectories(packageDir)
-                                               .Select(d => new
-                                               {
-                                                   Path = d,
-                                                   Version = d.PathGetFileName().ToRawVersion()
-                                               })
-                                               .Where(x => x.Version != null)
-                                               .OrderBy(x => x.Version);
-
-                        maxVersionPackage = packages.LastOrDefault()?.Path;
-                    }
-
-                    if (maxVersionPackage.IsNotEmpty())
-                    {
-                        var binDir = maxVersionPackage.PathCombine(@"tools\bin");
-                        if (IO.Directory.Exists(binDir))
-                            return binDir;
-                    }
-
-                }
-                return null;
-            }
-
-            var projectDir = projectFile.PathGetDirName();
-            var solutionDir = projectDir.PathGetDirName();
-            var globalPackages = Environment.ExpandEnvironmentVariables(@"%USERPROFILE%\.nuget\packages");
-
-            return probePackages(projectDir.PathCombine("packages"), false) ??
-                   probePackages(solutionDir.PathCombine("packages"), false) ??
-                   probePackages(globalPackages, true);
-        }
-
         static void EnsureVSIntegration()
         {
             try
             {
                 //Debug.Assert(false);
-                // /MSBUILD:$(ProjectName)
-                var preffix = "/MSBUILD:";
+                string projectName = ArgumentUtilities.GetArgumentValue(new[] { "/MSBUILD:", "/MBSBUILD:" });
 
-                string arg = Environment.GetCommandLineArgs().Where(x => x.StartsWith(preffix)).LastOrDefault() ?? "";
-
-                if (arg.IsEmpty())
+                if (projectName.IsNotEmpty())
                 {
-                    preffix = "/MBSBUILD:"; //early versions of NuGet packages had this typo
-                    arg = Environment.GetCommandLineArgs().Where(x => x.StartsWith(preffix)).LastOrDefault() ?? "";
-                }
-
-                if (arg.IsNotEmpty())
-                {
-                    //if building as part of the VS project with WixSharp NuGet package create (auto-generated) wxs file
-
-                    string projName = arg.Substring(preffix.Length);
-
                     //MSBuild always sets currdir to the project directory
-                    string projFile = IO.Path.Combine(Environment.CurrentDirectory, projName + ".csproj");
+                    string projFile = IO.Path.Combine(Environment.CurrentDirectory, projectName + ".csproj");
 
                     Environment.SetEnvironmentVariable("MSBUILD", "true");
                     Environment.SetEnvironmentVariable("MSBUILD_PROJ", projFile);
-                    Environment.SetEnvironmentVariable("MSBUILD_WIX_BIN", FindWixBinPackage(projFile));
-
                     var doc = XDocument.Load(projFile);
                     var ns = doc.Root.Name.Namespace;
 
@@ -367,7 +297,7 @@ namespace WixSharp
                     if (MSBuild.EmitAutoGenFiles)
                     {
                         string destDir = IO.Path.Combine(Environment.CurrentDirectory, "wix");
-                        autogeneratedWxsForVS = IO.Path.Combine(destDir, projName + ".g.wxs");
+                        autogeneratedWxsForVS = IO.Path.Combine(destDir, projectName + ".g.wxs");
 
                         if (!injected)
                         {
@@ -389,6 +319,8 @@ namespace WixSharp
             catch { }
         }
 
+
+
         /// <summary>
         /// Gets or sets the location of WiX binaries (compiler/linker/dlls).
         /// The default value is the content of environment variable <c>WIXSHARP_WIXDIR</c>.
@@ -403,39 +335,15 @@ namespace WixSharp
         {
             get
             {
-                if (wixLocation.IsEmpty()) //WixSharp did not set WIXSHARP_WIXDIR environment variable so check if the full WiX was installed
+                if (wixLocation.IsNotEmpty() && !IO.Directory.Exists(wixLocation))
                 {
-                    var dir = Environment.GetEnvironmentVariable("MSBUILD_WIX_BIN") ?? "";
-                    if (!IO.Directory.Exists(dir))
-                        dir = Environment.ExpandEnvironmentVariables("%WIX%\\bin");
+                    Console.Error.WriteLine($"The specified location {wixLocation} was not valid.  Trying other methods to find the Wix assemblies!");
+                    wixLocation = string.Empty;
+                }
 
-                    if (!IO.Directory.Exists(dir))
-                    {
-                        string wixDir = IO.Directory.GetDirectories(Utils.ProgramFilesDirectory, "Windows Installer XML v3*")
-                                                    .OrderBy(x => x)
-                                                    .LastOrDefault();
-
-                        if (wixDir.IsEmpty())
-                            wixDir = IO.Directory.GetDirectories(Utils.ProgramFilesDirectory, "WiX Toolset v3*")
-                                                 .OrderBy(x => x)
-                                                 .LastOrDefault();
-
-                        if (!wixDir.IsEmpty())
-                            dir = Utils.PathCombine(wixDir, "bin");
-                    }
-                    else
-                    {
-                        dir = IO.Path.GetFullPath(dir); //normalize
-                    }
-
-                    if (!IO.Directory.Exists(dir))
-                        throw new Exception("WiX binaries cannot be found. Wix# is capable of automatically finding WiX tools only if " +
-                                            "WiX Toolset installed. In all other cases you need to set the environment variable " +
-                                            "WIXSHARP_WIXDIR or WixSharp.Compiler.WixLocation to the valid path to the WiX binaries.\n" +
-                                            "WiX binaries can be brought to the build environment by either installing WiX Toolset, " +
-                                            "downloading Wix# suite or by adding WixSharp.wix.bin NuGet package to your project.");
-
-                    wixLocation = dir;
+                if (wixLocation.IsEmpty()) // Not set from the installer - find it now
+                {
+                    wixLocation = WixBinLocator.FindWixBinLocation();
                     Environment.SetEnvironmentVariable("WixLocation", wixLocation);
                 }
 
@@ -448,10 +356,9 @@ namespace WixSharp
             }
         }
 
-        static string wixLocation = Environment.GetEnvironmentVariable("WIXSHARP_WIXDIR");
+        static string wixLocation;
 
-        static string wixSdkLocation;
-
+        
         /// <summary>
         /// Gets or sets the location of WiX SDK binaries (e.g. MakeSfxCA.exe).
         /// The default value is the '..\SDK' or 'SDK' (whichever exist) sub-directory of WixSharp.Compiler.WixLocation directory.
@@ -468,14 +375,7 @@ namespace WixSharp
             get
             {
                 if (wixSdkLocation.IsEmpty())
-                    wixSdkLocation = IO.Path.GetFullPath(Utils.PathCombine(WixLocation, "..\\sdk"));
-
-                if (!IO.Directory.Exists(wixSdkLocation))
-                {
-                    wixSdkLocation = IO.Path.GetFullPath(Utils.PathCombine(WixLocation, "sdk")); //NuGet package shovels the dirs
-                    if (!IO.Directory.Exists(wixSdkLocation))
-                        throw new Exception("WiX SDK binaries cannot be found. Please set WixSharp.Compiler.WixSdkLocation to valid path to the Wix SDK binaries.");
-                }
+                    wixSdkLocation = WixBinLocator.FindWixSdkLocation(WixLocation);
 
                 return wixSdkLocation;
             }
@@ -484,6 +384,7 @@ namespace WixSharp
                 wixSdkLocation = value;
             }
         }
+        static string wixSdkLocation;
 
         /// <summary>
         /// Forces <see cref="Compiler"/> to preserve all temporary build files (e.g. *.wxs).

--- a/Source/src/WixSharp/Utilities/ArgumentUtilities.cs
+++ b/Source/src/WixSharp/Utilities/ArgumentUtilities.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace WixSharp.Utilities
+{
+    static class ArgumentUtilities
+    {
+        public static string GetArgumentValue(string[] possiblePreffixes)
+        {
+            foreach (var preffix in possiblePreffixes)
+            {
+                string arg = Environment.GetCommandLineArgs().Where(x => x.StartsWith(preffix, true)).LastOrDefault() ?? "";
+
+                if (arg.IsNotEmpty())
+                {
+                    return arg.Substring(preffix.Length);
+                }
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/Source/src/WixSharp/Utilities/WixBinLocator.cs
+++ b/Source/src/WixSharp/Utilities/WixBinLocator.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+
+namespace WixSharp.Utilities
+{
+    static class WixBinLocator
+    {
+        public static string FindWixSdkLocation(string wixLocation)
+        {
+            var wixSdkLocation = Path.GetFullPath(Utils.PathCombine(wixLocation, "..\\sdk"));
+
+            if (!Directory.Exists(wixSdkLocation))
+            {
+                wixSdkLocation = Path.GetFullPath(Utils.PathCombine(wixLocation, "sdk")); //NuGet package shovels the dirs
+                if (!Directory.Exists(wixSdkLocation))
+                    throw new Exception("WiX SDK binaries cannot be found. Please set WixSharp.Compiler.WixSdkLocation to valid path to the Wix SDK binaries.");
+            }
+
+            return wixSdkLocation;
+        }
+
+        public static string FindWixBinLocation()
+        {
+            // See if the command line was set for this property
+            var msBuildArgument = ArgumentUtilities.GetArgumentValue(new[] { "/WIXBIN:" });
+            if (!msBuildArgument.IsNullOrEmpty() && Directory.Exists(msBuildArgument))
+            {
+                return Path.GetFullPath(msBuildArgument);
+            }
+            
+            // Now check to see if the environment variable was set
+            var environmentVar = Environment.GetEnvironmentVariable("WIXSHARP_WIXDIR");
+            if (!environmentVar.IsNullOrEmpty() && Directory.Exists(environmentVar))
+            {
+                return Path.GetFullPath(environmentVar);
+            }
+
+            // Now check to see if the WIX install set an environment variable
+            var wixEnvironmentVariable = Environment.ExpandEnvironmentVariables("%WIX%\\bin");
+            if (!wixEnvironmentVariable.IsNullOrEmpty() && Directory.Exists(wixEnvironmentVariable))
+            {
+                return Path.GetFullPath(wixEnvironmentVariable);
+            }
+
+            // Now try the program files install location
+            string wixInstallDir = Directory.GetDirectories(Utils.ProgramFilesDirectory, "Windows Installer XML v3*")
+                                .OrderBy(x => x).LastOrDefault();
+            if (!wixInstallDir.IsNullOrEmpty() && Directory.Exists(wixInstallDir))
+            {
+                return Path.GetFullPath(Path.Combine(wixInstallDir, "bin"));
+            }
+
+            // Try a secondary location
+            wixInstallDir = Directory.GetDirectories(Utils.ProgramFilesDirectory, "WiX Toolset v3*")
+                    .OrderBy(x => x).LastOrDefault();
+            if (!wixInstallDir.IsNullOrEmpty() && Directory.Exists(wixInstallDir))
+            {
+                return Path.GetFullPath(Path.Combine(wixInstallDir, "bin"));
+            }
+
+            throw new Exception("WiX binaries cannot be found. Wix# is capable of automatically finding WiX tools only if " +
+                                            "WiX Toolset installed. In all other cases you need to set the environment variable " +
+                                            "WIXSHARP_WIXDIR or WixSharp.Compiler.WixLocation to the valid path to the WiX binaries.\n" +
+                                            "WiX binaries can be brought to the build environment by either installing WiX Toolset, " +
+                                            "downloading Wix# suite or by adding WixSharp.wix.bin NuGet package to your project.");
+        }
+    }
+}

--- a/Source/src/WixSharp/WixSharp.csproj
+++ b/Source/src/WixSharp/WixSharp.csproj
@@ -156,6 +156,8 @@
     <Compile Include="UACRevealer.cs" />
     <Compile Include="UrlReservation.cs" />
     <Compile Include="User.cs" />
+    <Compile Include="Utilities\ArgumentUtilities.cs" />
+    <Compile Include="Utilities\WixBinLocator.cs" />
     <Compile Include="WixExtension.cs" />
     <Compile Include="WixProject.cs" />
     <Compile Include="Controls\Control.cs" />


### PR DESCRIPTION
Modified locating logic for win package files.  Logic now searches in this order
1. Set location in installer project via Compiler.WixLocation
 a. If location is invalid, keep searching
2. Referenced package
3. Environment variable
4. Wix install