### PR TITLE
Allows to repair the MSI package

### DIFF
--- a/Source/src/WixSharp.Samples/Wix# Samples/AllInOne/MyAppWix.cs
+++ b/Source/src/WixSharp.Samples/Wix# Samples/AllInOne/MyAppWix.cs
@@ -63,6 +63,9 @@ class Script
 
             project.InstallPrivileges = InstallPrivileges.elevated;
 
+            // Optionally enable an ability to repair the installation even when the original MSI is no longer available.
+            project.EnableResilientPackage();
+
             // project.PreserveTempFiles = true;
             project.WixSourceGenerated += Compiler_WixSourceGenerated;
             project.BuildMsi();

--- a/Source/src/WixSharp/ResilientPackage.cs
+++ b/Source/src/WixSharp/ResilientPackage.cs
@@ -1,0 +1,307 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Deployment.WindowsInstaller;
+using WixSharp.CommonTasks;
+using WixSharp.Utilities;
+using IO = System.IO;
+
+namespace WixSharp
+{
+    /// <summary>
+    /// Allows to repair the MSI package even when the original installation package is no longer available.
+    /// <para>Adds an additional source of the resiliency by attempting to create a symbolic link to the locally cached MSI package (%WINDIR%\Installer)
+    /// or a hard link/full copy to the original installation MSI package in the specified directory.</para>
+    /// <para><c>WIXSHARP_RESILIENT_SOURCE_DIR</c> property can be used to configure the target directory. <c>INSTALLDIR property is used by default.</c></para>
+    /// <para>Windows 7 is shipped with the Windows Installer version 5.0, which unlike the previous versions of the windows installer caches the entire MSI,
+    /// including internal CAB files. Unfortunately the complete cached MSI package is not used for repairs, a call is made to the original source
+    /// which might not be available.
+    ///</para>
+    /// <para>See also:
+    /// <list type="bullet">
+    /// <item>https://docs.microsoft.com/en-us/windows/desktop/msi/source-resiliency</item>
+    /// <item>https://www.symantec.com/connect/articles/reducing-windows-installer-disk-wastage-windows-7</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public static class ResilientPackage
+    {
+        private const string WIXSHARP_PACKAGENAME = "WIXSHARP_PACKAGENAME";
+        private const string WIXSHARP_RESILIENT_SOURCE_DIR = "WIXSHARP_RESILIENT_SOURCE_DIR";
+
+        /// <summary>
+        /// Enables source resiliency for the installer.
+        /// Creates a symbolic link/hard link or makes a copy of the original MSI package in the specified location and points SOURCELIST to it.
+        /// The default resilient source directory is INSTALLDIR.
+        /// </summary>
+        /// <param name="project">The project.</param>
+        public static void EnableResilientPackage(this Project project)
+        {
+            project.EnableResilientPackage("[INSTALLDIR]");
+        }
+
+        /// <summary>
+        /// Enables source resiliency for the installer.
+        /// Creates a symbolic link/hard link or makes a copy of the original MSI package in the specified location and points SOURCELIST to it.
+        /// </summary>
+        /// <param name="project">The project.</param>
+        /// <param name="resilientSourceDir">Resilient source directory.</param>
+        public static void EnableResilientPackage(this Project project, string resilientSourceDir)
+        {
+            project.AddActions(
+                new SetPropertyAction(new Id($"WixSharp_SetProperty_{WIXSHARP_RESILIENT_SOURCE_DIR}"),
+                    WIXSHARP_RESILIENT_SOURCE_DIR, resilientSourceDir,
+                    Return.check,
+                    When.Before, Step.InstallInitialize,
+                    $"{WIXSHARP_RESILIENT_SOURCE_DIR}=\"\""),
+
+                new SetPropertyAction(new Id("WixSharp_SetProperty_SOURCELIST"),
+                    "SOURCELIST", $"[{WIXSHARP_RESILIENT_SOURCE_DIR}]",
+                    Return.check,
+                    When.Before, Step.PublishProduct,
+                    Condition.NOT_Installed)
+            );
+
+            var assembly = typeof(ResilientPackage).Assembly.Location;
+
+            project.AddActions(
+                new ManagedAction(new Id(nameof(WixSharp_SetPackageName_Action)),
+                    WixSharp_SetPackageName_Action, assembly,
+                    Return.ignore,
+                    When.Before, Step.InstallInitialize,
+                    Condition.BeingRemoved),
+
+                new ElevatedManagedAction(new Id(nameof(WixSharp_RemoveResilientPackage_Action)),
+                    WixSharp_RemoveResilientPackage_Action, assembly,
+                    Return.ignore,
+                    When.Before, Step.RemoveFiles,
+                    Condition.BeingRemoved)
+                {
+                    UsesProperties = $"{WIXSHARP_RESILIENT_SOURCE_DIR},{WIXSHARP_PACKAGENAME}"
+                },
+
+                new ElevatedManagedAction(new Id(nameof(WixSharp_CreateResilientPackage_Action)),
+                    WixSharp_CreateResilientPackage_Action, assembly,
+                    Return.ignore,
+                    When.Before, Step.InstallFinalize,
+                    Condition.NOT_Installed | "REINSTALL<>\"\"")
+                {
+                    UsesProperties = $"UserSID,OriginalDatabase,ALLUSERS,{WIXSHARP_RESILIENT_SOURCE_DIR}"
+                }
+            );
+        }
+
+        /// <summary>
+        /// Internal ResilientPackage action. It must be public for the DTF accessibility but it is not to be used by the user/developer.
+        /// </summary>
+        /// <param name="session">The session.</param>
+        /// <returns></returns>
+        [CustomAction]
+        public static ActionResult WixSharp_SetPackageName_Action(Session session)
+        {
+            return session.HandleErrors(() =>
+            {
+                var productCode = session.Property("ProductCode");
+
+                string packageName = null;
+                try
+                {
+                    packageName = GetPackageName(productCode);
+                }
+                catch (Exception e)
+                {
+                    session.Log(e.ToString());
+                }
+
+                if (packageName.IsEmpty())
+                {
+                    packageName = GetPackageNameFromRegistry(productCode);
+                }
+
+                session[WIXSHARP_PACKAGENAME] = packageName;
+            });
+        }
+
+        /// <summary>
+        /// Internal ResilientPackage action. It must be public for the DTF accessibility but it is not to be used by the user/developer.
+        /// </summary>
+        /// <param name="session">The session.</param>
+        /// <returns></returns>
+        [CustomAction]
+        public static ActionResult WixSharp_RemoveResilientPackage_Action(Session session)
+        {
+            return session.HandleErrors(() =>
+            {
+                var packageName = session.Property(WIXSHARP_PACKAGENAME);
+                var resilientLocation = session.Property(WIXSHARP_RESILIENT_SOURCE_DIR);
+                var resilientPackage = IO.Path.Combine(resilientLocation, packageName);
+
+                IO.File.Delete(resilientPackage);
+            });
+        }
+
+        /// <summary>
+        /// Internal ResilientPackage action. It must be public for the DTF accessibility but it is not to be used by the user/developer.
+        /// </summary>
+        /// <param name="session">The session.</param>
+        /// <returns></returns>
+        [CustomAction]
+        public static ActionResult WixSharp_CreateResilientPackage_Action(Session session)
+        {
+            return session.HandleErrors(() => CreateResilientPackage(session));
+        }
+
+        [Flags]
+        internal enum SymbolicLinkFlag
+        {
+            File = 0,
+            Directory = 1,
+            AllowUnprivilegedCreate = 2
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal static extern bool CreateSymbolicLink(string lpSymlinkFileName, string lpTargetFileName, SymbolicLinkFlag dwFlags);
+
+        [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
+        internal static extern bool CreateHardLink(string lpFileName, string lpExistingFileName, IntPtr lpSecurityAttributes);
+
+        private static void CreateResilientPackage(Session session)
+        {
+            var productCode = session.Property("ProductCode");
+
+            var userSID = session.Property("ALLUSERS") == "1" ? "S-1-5-18" : session.Property("UserSID");
+            var localPackage = GetLocalPackageFromRegistry(productCode, userSID);
+
+            session.Log("LocalPackage: " + localPackage);
+
+            var resilientLocation = session.Property(WIXSHARP_RESILIENT_SOURCE_DIR);
+            var originalPackage = session.Property("OriginalDatabase");
+            var packageName = IO.Path.GetFileName(originalPackage);
+            if (string.IsNullOrEmpty(packageName))
+            {
+                throw new ArgumentNullException($"PackageName is null.");
+            }
+            var resilientPackage = IO.Path.Combine(resilientLocation, packageName);
+
+            var resilientPackageInfo = new IO.FileInfo(resilientPackage);
+            if (resilientPackageInfo.Exists && resilientPackage.Equals(originalPackage, StringComparison.OrdinalIgnoreCase) && !IsSymbolicLink(resilientPackageInfo))
+            {
+                return;
+            }
+
+            IO.File.Delete(resilientPackage);
+
+            // Create a symbolic link
+            var result = CreateSymbolicLink(resilientPackage, localPackage, SymbolicLinkFlag.File);
+            if (!result)
+            {
+                var errorMessage = new Win32Exception(Marshal.GetLastWin32Error()).Message;
+                session.Log($"Failed to create a symbolic link. Link:{resilientPackage} Target:{localPackage} Error:{errorMessage}");
+            }
+
+            // Create a hard link
+            if (!result)
+            {
+                result = CreateHardLink(resilientPackage, originalPackage, IntPtr.Zero);
+                if (!result)
+                {
+                    var errorMessage = new Win32Exception(Marshal.GetLastWin32Error()).Message;
+                    session.Log($"Failed to create a hard link. Link:{resilientPackage} Target:{localPackage} Error:{errorMessage}");
+                }
+            }
+
+            // Copy the file
+            if (!result)
+            {
+                IO.File.Copy(originalPackage, resilientPackage, true);
+            }
+        }
+
+        private static string Reverse(string s)
+        {
+            char[] charArray = s.ToCharArray();
+            Array.Reverse(charArray);
+            return new string(charArray);
+        }
+
+        private static string CompressGUID(string guid)
+        {
+            var builder = new StringBuilder(5);
+            var parts = guid.Trim('{', '}').Split('-');
+
+            for (var ix = 0; ix < 3; ++ix)
+            {
+                builder.Append(Reverse(parts[ix]));
+            }
+
+            var tail = parts[3] + parts[4];
+            for (var ix = 0; ix < tail.Length; ix += 2)
+            {
+                builder.Append(tail[ix + 1]);
+                builder.Append(tail[ix]);
+            }
+            return builder.ToString();
+        }
+
+        private static string GetLocalPackageFromRegistry(string productCode, string userSID)
+        {
+            var compressedGuid = CompressGUID(productCode);
+            var keyName = $@"SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\{userSID}\Products\{compressedGuid}\InstallProperties";
+
+            return RegistryWOW6432.GetRegKey64(RegHive.HKEY_LOCAL_MACHINE, keyName, "LocalPackage");
+
+            // NOTE: Remove RegistryWOW6432 and replace with the following code once move to .Net Framework 4+
+            //
+            // string localPackage;
+            // using (var localKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64))
+            // {
+            //     using (var installProperties = localKey.OpenSubKey(keyName, false))
+            //     {
+            //         localPackage = (string)installProperties?.GetValue("LocalPackage");
+            //     }
+            // }
+            //
+            // return localPackage;
+        }
+
+        private static string GetPackageName(string productCode)
+        {
+            var product = new ProductInstallation(productCode);
+            return product.AdvertisedPackageName;
+        }
+
+        private static string GetPackageNameFromRegistry(string productCode)
+        {
+            var compressedGuid = CompressGUID(productCode);
+            var keyName = $@"SOFTWARE\Classes\Installer\Products\{compressedGuid}\SourceList";
+
+            return RegistryWOW6432.GetRegKey64(RegHive.HKEY_LOCAL_MACHINE, keyName, "PackageName");
+
+            // NOTE: Remove RegistryWOW6432 and replace with the following code once move to .Net Framework 4+
+            //
+            // string packageName;
+            //
+            // using (var localKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64))
+            // {
+            //     using (var sourceList = localKey.OpenSubKey(keyName, false))
+            //     {
+            //         packageName = (string)sourceList?.GetValue("PackageName");
+            //     }
+            // }
+            // return packageName;
+        }
+
+        // ReSharper disable once UnusedMember.Local
+        private static bool IsSymbolicLink(string path)
+        {
+            var fileInfo = new IO.FileInfo(path);
+            return IsSymbolicLink(fileInfo);
+        }
+
+        private static bool IsSymbolicLink(IO.FileInfo fileInfo)
+        {
+            return (fileInfo.Attributes & IO.FileAttributes.ReparsePoint) != 0;
+        }
+    }
+}

--- a/Source/src/WixSharp/Utilities/RegistryWOW6432.cs
+++ b/Source/src/WixSharp/Utilities/RegistryWOW6432.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+// http://www.rhyous.com/2011/01/24/how-read-the-64-bit-registry-from-a-32-bit-application-or-vice-versa/
+// https://stackoverflow.com/questions/26217199/what-are-some-alternatives-to-registrykey-openbasekey-in-net-3-5
+namespace WixSharp.Utilities
+{
+    #region Enums
+    enum RegSAM
+    {
+        QueryValue = 0x0001,
+        SetValue = 0x0002,
+        CreateSubKey = 0x0004,
+        EnumerateSubKeys = 0x0008,
+        Notify = 0x0010,
+        CreateLink = 0x0020,
+        WOW64_32Key = 0x0200,
+        WOW64_64Key = 0x0100,
+        WOW64_Res = 0x0300,
+        Read = 0x00020019,
+        Write = 0x00020006,
+        Execute = 0x00020019,
+        AllAccess = 0x000f003f
+    }
+    #endregion
+
+    static class RegHive
+    {
+        public static UIntPtr HKEY_LOCAL_MACHINE = new UIntPtr(0x80000002u);
+        public static UIntPtr HKEY_CURRENT_USER = new UIntPtr(0x80000001u);
+    }
+
+    static class RegistryWOW6432
+    {
+        #region Member Variables
+        #region Read 64bit Reg from 32bit app
+        [DllImport("Advapi32.dll")]
+        static extern uint RegOpenKeyEx(
+            UIntPtr hKey,
+            string lpSubKey,
+            uint ulOptions,
+            int samDesired,
+            out int phkResult);
+
+        [DllImport("Advapi32.dll")]
+        static extern uint RegCloseKey(int hKey);
+
+        [DllImport("advapi32.dll", EntryPoint = "RegQueryValueEx")]
+        static extern int RegQueryValueEx(
+            int hKey, string lpValueName,
+            int lpReserved,
+            ref uint lpType,
+            StringBuilder lpData,
+            ref uint lpcbData);
+        #endregion
+        #endregion
+
+        #region Functions
+        public static string GetRegKey64(UIntPtr inHive, String inKeyName, String inPropertyName)
+        {
+            return GetRegKey64(inHive, inKeyName, RegSAM.WOW64_64Key, inPropertyName);
+        }
+
+        public static string GetRegKey32(UIntPtr inHive, String inKeyName, String inPropertyName)
+        {
+            return GetRegKey64(inHive, inKeyName, RegSAM.WOW64_32Key, inPropertyName);
+        }
+
+        public static string GetRegKey64(UIntPtr inHive, String inKeyName, RegSAM in32or64key, String inPropertyName)
+        {
+            int hkey = 0;
+
+            try
+            {
+                uint lResult = RegOpenKeyEx(RegHive.HKEY_LOCAL_MACHINE, inKeyName, 0, (int)RegSAM.QueryValue | (int)in32or64key, out hkey);
+                if (0 != lResult) return null;
+                uint lpType = 0;
+                uint lpcbData = 1024;
+                StringBuilder AgeBuffer = new StringBuilder(1024);
+                RegQueryValueEx(hkey, inPropertyName, 0, ref lpType, AgeBuffer, ref lpcbData);
+                string Age = AgeBuffer.ToString();
+                return Age;
+            }
+            finally
+            {
+                if (0 != hkey) RegCloseKey(hkey);
+            }
+        }
+        #endregion
+    }
+}

--- a/Source/src/WixSharp/WixSharp.csproj
+++ b/Source/src/WixSharp/WixSharp.csproj
@@ -148,6 +148,7 @@
     <Compile Include="RegistrySearch.cs" />
     <Compile Include="RemoveRegistryValue.cs" />
     <Compile Include="RemoveRegistryKey.cs" />
+    <Compile Include="ResilientPackage.cs" />
     <Compile Include="SharedExtensions.cs" />
     <Compile Include="SqlDatabase.cs" />
     <Compile Include="SqlScript.cs" />
@@ -156,6 +157,7 @@
     <Compile Include="UACRevealer.cs" />
     <Compile Include="UrlReservation.cs" />
     <Compile Include="User.cs" />
+    <Compile Include="Utilities\RegistryWOW6432.cs" />
     <Compile Include="Utilities\WixBinLocator.cs" />
     <Compile Include="WixExtension.cs" />
     <Compile Include="WixProject.cs" />


### PR DESCRIPTION
Adds an extension method project.EnableResilientPackage() which allows to repair the MSI package even when the original installation package is no longer available.

Adds an additional source of the resiliency by attempting to create a symbolic link to the locally cached MSI package (%WINDIR%\Installer) or a hard link/full copy to the original installation MSI package in the specified directory.

WIXSHARP_RESILIENT_SOURCE_DIR property can be used to configure the target directory. INSTALLDIR property is used by default.

Windows 7 is shipped with the Windows Installer version 5.0, which unlike the previous versions of the windows installer caches the entire MSI, including internal CAB files. Unfortunately the complete cached MSI package is not used for repairs, a call is made to the original source which might not be available.

See also:

https://docs.microsoft.com/en-us/windows/desktop/msi/source-resiliency
https://www.symantec.com/connect/articles/reducing-windows-installer-disk-wastage-windows-7