### PR TITLE
An empty directory remains after the uninstall #464

### DIFF
--- a/Source/src/WixSharp/WixEntity.cs
+++ b/Source/src/WixSharp/WixEntity.cs
@@ -285,7 +285,7 @@ namespace WixSharp
         internal string GenerateComponentId(Project project, string suffix = "")
         {
             return this.GetExplicitComponentId() ??
-                   project.ComponentId($"Component{suffix}.{this.Id}");
+                   project.ComponentId($"Component.{this.Id}{suffix}");
         }
 
         internal string GetExplicitComponentId()


### PR DESCRIPTION
Steps to reproduce:

Use a real certificate with the "Certificate" sample
Install/uninstall the MSI
Observe that an empty "%ProgramFiles%\My Company" remains after the uninstall
The issue is related to components without files or registry elements, in this particular case a component with the Certificate element. The WixSharp already contains a workaround code to inject "RemoveFolder" for a parent directory of the component, but it looks like it's not enough, it should be done for all chain of parent folders.