### PR TITLE
Add missing parenthesis to example.

### DIFF
--- a/Source/src/WixSharp/CloseApplication.cs
+++ b/Source/src/WixSharp/CloseApplication.cs
@@ -7,7 +7,7 @@
     /// <code>
     /// var project =
     ///     new Project("My Product",
-    ///         new CustomActionRef("WixCloseApplications", When.Before, Step.CostFinalize, new Condition("VersionNT > 400"),
+    ///         new CustomActionRef("WixCloseApplications", When.Before, Step.CostFinalize, new Condition("VersionNT > 400")),
     ///         new CloseApplication("MyApp.exe", true, false)),
     ///         ...
     /// Compiler.BuildMsi(project);


### PR DESCRIPTION
There is a missing closing brace to the example within the comment of CloseApplication