### PR TITLE
Add an aggregate registry key class

### DIFF
--- a/Source/src/WixSharp/CommonTasks.cs
+++ b/Source/src/WixSharp/CommonTasks.cs
@@ -571,6 +571,16 @@ namespace WixSharp.CommonTasks
         }
 
         /// <summary>
+        /// Adds the registry key to the Project.
+        /// </summary>
+        /// <param name="project">The project.</param>
+        /// <param name="key">The key.</param>
+        public static void AddRegKey(this Project project, RegKey key)
+        {
+            project.AddRegValues(key.GetValues());
+        }
+
+        /// <summary>
         /// Adds the registry values to the Project.
         /// </summary>
         /// <param name="project">The project.</param>

--- a/Source/src/WixSharp/Project.cs
+++ b/Source/src/WixSharp/Project.cs
@@ -140,6 +140,8 @@ namespace WixSharp
                         actions.Add(item as Action);
                     else if (item is RegValue)
                         regs.Add(item as RegValue);
+                    else if (item is RegKey regkey)
+                        regs.AddRange(regkey.GetValues());
                     else if (item is RegFile)
                     {
                         var file = item as RegFile;

--- a/Source/src/WixSharp/RegKey.cs
+++ b/Source/src/WixSharp/RegKey.cs
@@ -1,0 +1,55 @@
+﻿namespace WixSharp
+{
+    public class RegKey
+    {
+        /// <summary>
+        /// <see cref="Feature"></see> the registry value should be included in.
+        /// </summary>
+        public Feature Feature;
+
+        /// <summary>
+        /// The registry hive name.
+        /// </summary>
+        public RegistryHive Root;
+
+        /// <summary>
+        /// The registry key name.
+        /// </summary>
+        public string Key;
+
+        /// <summary>
+        /// Facilitates the installation of packages that include both 32-bit and 64-bit components.
+        /// Set this attribute to 'yes' to mark the corresponding RegValue as a 64-bit component.
+        /// </summary>
+        public bool Win64;
+
+        internal RegValue[] GetValues()
+        {
+            foreach (var value in _values)
+            {
+                value.Feature = Feature;
+                value.Root = Root;
+                value.Key = Key;
+                value.Win64 = Win64;
+            }
+            return _values;
+        }
+
+        private readonly RegValue[] _values;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegKey"/> class with properties initialized with specified parameters.
+        /// </summary>
+        /// <param name="feature"><see cref="Feature"></see> the registry value should be included in.</param>
+        /// <param name="root">The registry hive name.</param>
+        /// <param name="key">The registry key name.</param>
+        /// <param name="values">The registry entry values.</param>
+        public RegKey(Feature feature, RegistryHive root, string key, params RegValue[] values)
+        {
+            Feature = feature;
+            Root = root;
+            Key = key;
+            _values = values;
+        }
+    }
+}

--- a/Source/src/WixSharp/RegKey.cs
+++ b/Source/src/WixSharp/RegKey.cs
@@ -1,11 +1,10 @@
 ﻿namespace WixSharp
 {
-    public class RegKey
+    /// <summary>
+    /// Aggregate class for multiple <see cref="RegValue"/> with the same root key
+    /// </summary>
+    public class RegKey : WixObject
     {
-        /// <summary>
-        /// <see cref="Feature"></see> the registry value should be included in.
-        /// </summary>
-        public Feature Feature;
 
         /// <summary>
         /// The registry hive name.

--- a/Source/src/WixSharp/RegValue.cs
+++ b/Source/src/WixSharp/RegValue.cs
@@ -153,6 +153,17 @@ namespace WixSharp
         /// <summary>
         /// Initializes a new instance of the <see cref="RegValue"/> class with properties initialized with specified parameters.
         /// </summary>
+        /// <param name="name">The registry entry name.</param>
+        /// <param name="value">The registry entry value.</param>
+        public RegValue(string name, object value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegValue"/> class with properties initialized with specified parameters.
+        /// </summary>
         /// <param name="key">The registry key name.</param>
         /// <param name="name">The registry entry name.</param>
         /// <param name="value">The registry entry value.</param>

--- a/Source/src/WixSharp/WixSharp.csproj
+++ b/Source/src/WixSharp/WixSharp.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Properties\AssemblyInfo.version.cs" />
     <Compile Include="Reboot.cs" />
     <Compile Include="RegistrySearch.cs" />
+    <Compile Include="RegKey.cs" />
     <Compile Include="RemoveRegistryValue.cs" />
     <Compile Include="RemoveRegistryKey.cs" />
     <Compile Include="ResilientPackage.cs" />


### PR DESCRIPTION
This allows someone to create a set of registry values under the same key e.g:

```c#
 var regKey = new RegKey(feature, RegistryHive.LocalMachine, @"Software/My Company/My Product",
                new RegValue("InstallDir", "[INSTALLDIR]"),
                new RegValue("ProductCode", $"{project.GUID}"),
                new RegValue("Version", $"{project.Version}"),
                new RegValue("InstallLocale", "!(loc.culture)")
                ) { Win64 = project.Platform == Platform.x64 };

project.AddRegKey(regKey);
```