### PR TITLE
Add a secure attribute to property

### DIFF
--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -2562,6 +2562,8 @@ namespace WixSharp
                                                .SetAttribute("Id", prop.Name)
                                                .SetAttribute("Value", prop.Value)
                                                .AddAttributes(prop.Attributes));
+                    if (prop.Secure.HasValue)
+                        parentElement.SetAttribute("Secure", prop.Secure.Value.ToYesNo());
 
                     if (prop.GenericItems.Any())
                     {

--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -2561,9 +2561,8 @@ namespace WixSharp
                     var parentElement = product.AddElement(new XElement("Property")
                                                .SetAttribute("Id", prop.Name)
                                                .SetAttribute("Value", prop.Value)
+                                               .SetAttribute("Secure", prop.Secure)
                                                .AddAttributes(prop.Attributes));
-                    if (prop.Secure.HasValue)
-                        parentElement.SetAttribute("Secure", prop.Secure.Value.ToYesNo());
 
                     if (prop.GenericItems.Any())
                     {

--- a/Source/src/WixSharp/Property.cs
+++ b/Source/src/WixSharp/Property.cs
@@ -192,6 +192,11 @@ namespace WixSharp
         public bool IsDeferred = false;
 
         /// <summary>
+        /// The flag indicating if the property can be passed to the server side when doing a managed installation with elevated privileges.
+        /// </summary>
+        public bool? Secure;
+
+        /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
         /// </summary>
         /// <returns>


### PR DESCRIPTION
This adds an additional nullable boolean member to the Property class which then emits the Secure attribute in the property xml:

```c#
project.AddProperty(
    new Property("Gritting", "Hello World!"){ Secure = true });
```

```xml
    <Property Id="Gritting" Value="Hello World!" Secure="yes" />
```