### PR TITLE
New class to encapsulate a public property which must be uppercase

### DIFF
--- a/Source/src/WixSharp.Samples/Wix# Samples/Properties/setup.cs
+++ b/Source/src/WixSharp.Samples/Wix# Samples/Properties/setup.cs
@@ -29,7 +29,7 @@ class Script
             {
                 new Property("Gritting", "Hello World!"),
                 new Property("Title", "Properties Test"),
-                new Property("NOTEPAD_FILE", @"C:\boot.ini")
+                new PublicProperty("NOTEPAD_FILE", @"C:\boot.ini")
             }
         };
 

--- a/Source/src/WixSharp/Property.cs
+++ b/Source/src/WixSharp/Property.cs
@@ -207,4 +207,44 @@ namespace WixSharp
             return Name;
         }
     }
+
+    /// <summary>
+    /// Public properties are exposed on the msiexec commandline and can be overridden
+    /// i.e. msiexec /i myProduct.msi MYPROPERTY=true
+    /// They must be upper-case as this is part of the msi specification.
+    /// </summary>
+    public class PublicProperty : Property
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PublicProperty"/> class with properties/fields initialized with specified parameters.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="value">The initial value of the property.</param>
+        public PublicProperty(string name, string value)
+        {
+            CheckName(name);
+            Name = name;
+            Value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PublicProperty"/> class with properties/fields initialized with specified parameters.
+        /// </summary>
+        /// <param name="id">The explicit <see cref="Id"></see> to be associated with <see cref="PublicProperty"/> instance.</param>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="value">The initial value of the property.</param>
+        public PublicProperty(Id id, string name, string value) : this(name, value)
+        {
+            Id = id.Value;
+        }
+
+        private void CheckName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new System.ArgumentException("Public property name cannot be null or empty");
+
+            if (name.ToUpperInvariant() != name)
+                throw new System.ArgumentException("Public property names must be uppercase");
+        }
+    }
 }


### PR DESCRIPTION
The intention of this class is to make it easier for programmers to understand that public properties need to be uppercase.