### PR TITLE
Dir.AddItems() skips null items instead of throwing.

### DIFF
--- a/Source/src/WixSharp/Dir.cs
+++ b/Source/src/WixSharp/Dir.cs
@@ -400,6 +400,8 @@ namespace WixSharp
                     odbcSources.Add(item as ODBCDataSource);
                 else if (item is IISVirtualDir)
                     iisVirtualDirs.Add(item as IISVirtualDir);
+                else if (item is null)
+                    continue;
                 else
                     throw new Exception(item.GetType().Name + " is not expected to be a child of WixSharp.Dir");
 


### PR DESCRIPTION
Use case: DirFiles() adds a filtered list of files to a directory. If one of the binaries is marked as Windows service, filter skips this file defers adding this file to a block that assigns ServiceInstaller instance to WixSharp.File using a previously declared local variable. Since WixSharp overwrites its file collections, building those incrementally on an instance of project is impossible (I might explore a PR in that respect). I pass this WixSharp.File variable with initialized ServiceInstaller instance to the InstallDir c-tor as part of params WixEntity[]. This variable might be null and AddItems was tripping on that.