### PR TITLE
Fix 2 typos

### DIFF
--- a/Source/src/WixSharp.Samples/Wix# Samples/Properties/setup.cs
+++ b/Source/src/WixSharp.Samples/Wix# Samples/Properties/setup.cs
@@ -21,7 +21,7 @@ class Script
 
             Actions = new WixSharp.Action[]
             {
-                new ManagedAction(CustonActions.ShowGritting),
+                new ManagedAction(CustomActions.ShowGritting),
                 new WixQuietExecAction("notepad.exe", "[NOTEPAD_FILE]"),
             },
 
@@ -38,7 +38,7 @@ class Script
     }
 }
 
-public class CustonActions
+public class CustomActions
 {
     [CustomAction]
     public static ActionResult ShowGritting(Session session)

--- a/Source/src/WixSharp/Extensions.cs
+++ b/Source/src/WixSharp/Extensions.cs
@@ -1209,7 +1209,7 @@ namespace WixSharp
         }
 
         /// <summary>
-        /// Determines whether the value is a WiX constant (e.g. 'SystenFolder').
+        /// Determines whether the value is a WiX constant (e.g. 'SystemFolder').
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>


### PR DESCRIPTION
In both cases a 'n' was used instead of a 'm'.

Thx for your great work on this project.