### PR TITLE
Fix collision possibility for GetHashCode32()

### DIFF
--- a/Source/src/WixSharp.Samples/Wix# Samples/Custom_IDs/setup.cs
+++ b/Source/src/WixSharp.Samples/Wix# Samples/Custom_IDs/setup.cs
@@ -132,7 +132,7 @@ class Script
 
                 // WiX does not allow '-' char in ID. So need to use `Math.Abs`
 
-                var dir_hash = Math.Abs(target_path.PathGetDirName().GetHashCode32());
+                var dir_hash = (uint) target_path.PathGetDirName().GetHashCode32();
                 var file_name = target_path.PathGetFileName().EscapeIllegalCharacters();
 
                 return "File.{0}.{1}".FormatWith(dir_hash, file_name);

--- a/Source/src/WixSharp/Project.cs
+++ b/Source/src/WixSharp/Project.cs
@@ -840,7 +840,7 @@ namespace WixSharp
                 var hash = target_path.GetHashCode32();
 
                 // WiX does not allow '-' char in ID. So need to use `Math.Abs`
-                return $"{target_path.PathGetFileName()}_{Math.Abs(hash)}";
+                return $"{target_path.PathGetFileName()}_{(uint) hash}";
             }
             return null; // next two lines produce the same result
                          // return WixEntity.DefaultIdAlgorithm(entity);
@@ -1045,7 +1045,7 @@ namespace WixSharp
             {
                 var target_path = this.GetTargetPathOf(file);
 
-                var dir_hash = Math.Abs(target_path.GetHashCode32());
+                var dir_hash = (uint) target_path.GetHashCode32();
                 var file_name = target_path.PathGetFileName().EscapeIllegalCharacters();
 
                 if (Compiler.AutoGeneration.HashedTargetPathIdAlgorithm_FileIdMask != null)


### PR DESCRIPTION
Fix collision possibility for GetHashCode32(): use (uint) instead of Math.Abs()