### PR TITLE
Improvements to digital signatures. Support for signing using SHA1, SHA256, or both

### DIFF
--- a/Source/src/WixSharp/DigitalSignature.cs
+++ b/Source/src/WixSharp/DigitalSignature.cs
@@ -90,7 +90,7 @@ namespace WixSharp
         public virtual int Apply(string fileToSign)
         {
             var retValue = CommonTasks.Tasks.DigitalySign(fileToSign, CertificateId, TimeUrl?.AbsoluteUri, Password,
-                PrepareOptionalArguments(), WellKnownLocations, CertificateStore, false, OutputLevel, HashAlgorithm);
+                PrepareOptionalArguments(), WellKnownLocations, CertificateStore, OutputLevel, HashAlgorithm);
 
             Console.WriteLine(retValue != 0
                 ? $"Error: Could not sign the {fileToSign} file."

--- a/Source/src/WixSharp/DigitalSignatureBootstrapper.cs
+++ b/Source/src/WixSharp/DigitalSignatureBootstrapper.cs
@@ -15,7 +15,7 @@ namespace WixSharp
         public override int Apply(string bootstrapperFileToSign)
         {
             var retValue = CommonTasks.Tasks.DigitalySignBootstrapper(bootstrapperFileToSign, PfxFilePath, TimeUrl?.AbsoluteUri, Password,
-                PrepareOptionalArguments(), WellKnownLocations, UseCertificateStore, false, OutputLevel);
+                PrepareOptionalArguments(), WellKnownLocations, UseCertificateStore, OutputLevel, HashAlgorithm);
             Console.WriteLine(retValue != 0
                 ? $"Could not sign the {bootstrapperFileToSign} Bootstrapper file."
                 : $"The Bootstrapper file {bootstrapperFileToSign} was signed successfully.");

--- a/Source/src/WixSharp/Enums.cs
+++ b/Source/src/WixSharp/Enums.cs
@@ -392,10 +392,11 @@ namespace WixSharp
         sha1Hash
     }
 
+    [Flags]
     public enum HashAlgorithmType
     {
-        sha1,
-        sha256
+        sha1 = 0x01,
+        sha256 = 0x02
     }
 
 #pragma warning restore 1591


### PR DESCRIPTION
Hello Oleg,

This is for issue: https://github.com/oleg-shilo/wixsharp/issues/860

I have verified that I can sign using SHA1, SHA256, and dual sign. Apparently you cannot dual sign an msi, so if you dual sign, the msi will be signed with SHA1. 

I am not sure how to write a unit test without having a code signing cert available.