### PR TITLE
DigitalSignature support has been added to the NsisBootstrapper

### DIFF
--- a/Source/src/WixSharp.Samples/Wix# Samples/Bootstrapper/NsisBootstrapper/setup.cs
+++ b/Source/src/WixSharp.Samples/Wix# Samples/Bootstrapper/NsisBootstrapper/setup.cs
@@ -88,7 +88,7 @@ public static class Script
         {
             Prerequisite = {FileName = prerequisiteFile},
             Primary = {FileName = msiFile},
-            OutputFile = $"MyProduct{Path.GetExtension(prerequisiteFile)}.exe"
+            OutputFile = "MyProduct" + Path.GetExtension(prerequisiteFile) + ".exe"
         };
 
         bootstrapper.Build();

--- a/Source/src/WixSharp/Nsis/NsisBootstrapper.cs
+++ b/Source/src/WixSharp/Nsis/NsisBootstrapper.cs
@@ -113,6 +113,11 @@ namespace WixSharp.Nsis
         public SplashScreen SplashScreen { get; set; }
 
         /// <summary>
+        /// Gets or sets digital signature parameters for the bootstrapper.
+        /// </summary>
+        public DigitalSignature DigitalSignature;
+
+        /// <summary>
         /// Builds bootstrapper file.
         /// </summary>
         /// <returns>Path to the built bootstrapper file. Returns <c>null</c> if bootstrapper cannot be built.</returns>
@@ -219,6 +224,9 @@ namespace WixSharp.Nsis
             {
                 IO.File.Delete(nsiFile);
             }
+
+            DigitalSignature?.Apply(OutputFile);
+
             return OutputFile;
         }
 

--- a/Source/src/WixSharp/Project.cs
+++ b/Source/src/WixSharp/Project.cs
@@ -183,7 +183,7 @@ namespace WixSharp
         public string Description = "";
 
         /// <summary>
-        /// Parameters of digitaly sign of this project
+        /// Parameters of digitally sign of this project
         /// </summary>
         public DigitalSignature DigitalSignature;
 

--- a/Source/src/WixSharp/ResilientPackage.cs
+++ b/Source/src/WixSharp/ResilientPackage.cs
@@ -37,11 +37,11 @@ namespace WixSharp
         /// <param name="project">The project.</param>
         public static void EnableResilientPackage(this Project project)
         {
-            project.EnableResilientPackage("{$ResilientPackageIstallDir}");
+            project.EnableResilientPackage("{$ResilientPackageInstallDir}");
 
             project.WixSourceFormated += (ref string content) =>
             {
-                content = content.Replace("{$ResilientPackageIstallDir}", project.ActualInstallDirId);
+                content = content.Replace("{$ResilientPackageInstallDir}", project.ActualInstallDirId);
             };
         }
 


### PR DESCRIPTION
Hi Oleg,
One option worth considering is to add DigitalSignature to the Compiler class and it can be default to sign all binary artifacts during the build process. Individually the signature parameters can be tweaked in project and bootstrapper classes if need.

Regards,
Tigran