### PR TITLE
Remove duplicated deferred properties.

### DIFF
--- a/Source/src/WixSharp/ManagedProject/ManagedProject.cs
+++ b/Source/src/WixSharp/ManagedProject/ManagedProject.cs
@@ -264,6 +264,7 @@ namespace WixSharp
                                             .Concat(defaultDeferredProperties.Split(','))
                                             .Where(x => x.IsNotEmpty())
                                             .Select(x => x.Trim())
+                                            .Distinct()
                                             .ToArray());
             }
         }


### PR DESCRIPTION
Default deferred property may duplicate when setting `ManagedProject.DefaultDeferredProperties` after a deferred property has been added into the project with `ManagedProject.AddProperty()`. The issue can be reproduced as follow (using `WixSharp.Samples\VSProjects\Setup Events.csproj`:

```c#
project.AddProperty(new Property("Foo", "Bar") { IsDeferred = true });
// Add 'DefaultDeferredProperties' AFTER a deferred property is added. 
project.DefaultDeferredProperties += ",ADDLOCAL";
```

The fix also prevent duplication of deferred property when the same string is (accidentally) added multiple times.