### PR TITLE
Add "OS validation" functionality to NSIS bootstrapper

### DIFF
--- a/Source/src/WixSharp.Samples/Wix# Samples/Bootstrapper/NsisBootstrapper/setup.cs
+++ b/Source/src/WixSharp.Samples/Wix# Samples/Bootstrapper/NsisBootstrapper/setup.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 using Microsoft.Deployment.WindowsInstaller;
 using WixSharp;
 using WixSharp.Nsis;
+using WixSharp.Nsis.WinVer;
 
 public static class Script
 {
@@ -44,6 +45,12 @@ public static class Script
 
             // JScript script sample
             BuildScriptSample(msiFile, @"Assets\script.js");
+            
+            // BAT script sample with not supported win versions
+            BuildScriptSampleWithOSValidationWin7(msiFile, @"Assets\script.bat");
+            
+            // Another BAT script sample with not supported win versions
+            BuildScriptSampleWithOsValidationMultiple(msiFile, @"Assets\script.bat");
 
             // Arguments sample
             BuildArgumentsSample(msiFile);
@@ -96,6 +103,39 @@ public static class Script
             OutputFile = "MyProduct" + Path.GetExtension(prerequisiteFile) + ".exe"
         };
 
+        bootstrapper.Build();
+    }
+    
+    public static void BuildScriptSampleWithOsValidationMultiple(string msiFile, string prerequisiteFile)
+    {
+        var bootstrapper = new NsisBootstrapper
+        {
+            Prerequisite = {FileName = prerequisiteFile},
+            Primary = {FileName = msiFile},
+            OutputFile = "NotSupportedMultiple" + Path.GetExtension(prerequisiteFile) + ".exe"
+        };
+
+        bootstrapper.OSValidation.MinVersion = WindowsVersionNumber._7;
+        bootstrapper.OSValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._7, 1));
+        bootstrapper.OSValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._10));
+
+        bootstrapper.OSValidation.TerminateInstallation = false;
+        bootstrapper.OSValidation.ErrorMessage = "Hello from custom error message!";
+        
+        bootstrapper.Build();
+    }
+    
+    public static void BuildScriptSampleWithOSValidationWin7(string msiFile, string prerequisiteFile)
+    {
+        var bootstrapper = new NsisBootstrapper
+        {
+            Prerequisite = {FileName = prerequisiteFile},
+            Primary = {FileName = msiFile},
+            OutputFile = "NotSupported7" + Path.GetExtension(prerequisiteFile) + ".exe"
+        };
+
+        bootstrapper.OSValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._7));
+        
         bootstrapper.Build();
     }
 

--- a/Source/src/WixSharp.Test/OSValidationTests.cs
+++ b/Source/src/WixSharp.Test/OSValidationTests.cs
@@ -1,0 +1,158 @@
+using WixSharp.Nsis.WinVer;
+using Xunit;
+
+namespace WixSharp.Test
+{
+    // ReSharper disable once InconsistentNaming
+    public class OSValidationTests
+    {
+        [Fact]
+        public void BuildVersionCheckScriptPart_WhenNoVersions_ShouldReturnEmptyString()
+        {
+            // Arrange
+            var notSup = CreateOsValidation();
+
+            // Act
+            var script = notSup.BuildVersionCheckScriptPart();
+
+            // Assert
+            Assert.True(script.Equals(string.Empty));
+        }
+        
+        [Fact]
+        public void BuildVersionCheckScriptPart_WhenExactVersion_ShouldCreateCorrectScript()
+        {
+            // Arrange
+            var correctScript = @"${If} ${IsWin7}
+!define MB_OK 0x00000000
+!define MB_ICONERROR 0x00000010
+System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+goto end
+${EndIf}
+";
+            var osValidation = CreateOsValidation();
+            osValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._7));
+
+            // Act
+            var script = osValidation.BuildVersionCheckScriptPart();
+
+            // Assert
+            Assert.Equal(script, correctScript);
+        }
+        
+        [Fact]
+        public void BuildVersionCheckScriptPart_WhenExactVersionSp_ShouldCreateCorrectScript()
+        {
+            // Arrange
+            var correctScript = @"${If} ${IsWin8}
+${AndIf} ${IsServicePack} 1
+!define MB_OK 0x00000000
+!define MB_ICONERROR 0x00000010
+System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+goto end
+${EndIf}
+";
+            var osValidation = CreateOsValidation();
+            osValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._8, 1));
+
+            // Act
+            var script = osValidation.BuildVersionCheckScriptPart();
+
+            // Assert
+            Assert.Equal(script, correctScript);
+        }
+        
+        [Fact]
+        public void BuildVersionCheckScriptPart_WhenMinVersion_ShouldCreateCorrectScript()
+        {
+            // Arrange
+            var correctScript = @"${Unless} ${AtLeastWin2012}
+!define MB_OK 0x00000000
+!define MB_ICONERROR 0x00000010
+System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+goto end
+${EndUnless}
+";
+            var osValidation = CreateOsValidation(); 
+            osValidation.MinVersion = WindowsVersionNumber._2012;
+
+            // Act
+            var script = osValidation.BuildVersionCheckScriptPart();
+
+            // Assert
+            Assert.Equal(script, correctScript);
+        }
+        
+        [Fact]
+        public void BuildVersionCheckScriptPart_WhenCombinationOfVersions_ShouldCreateCorrectScript()
+        {
+            // Arrange
+            var correctScript = @"${Unless} ${AtLeastWin7}
+${OrIf} ${IsWin8}
+${OrIf} ${IsWin2008}
+${AndIf} ${IsServicePack} 0
+!define MB_OK 0x00000000
+!define MB_ICONERROR 0x00000010
+System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+goto end
+${EndUnless}
+";
+            var osValidation = CreateOsValidation();
+            osValidation.MinVersion = WindowsVersionNumber._7;
+            osValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._8));
+            osValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._2008, 0));
+
+            // Act
+            var script = osValidation.BuildVersionCheckScriptPart();
+
+            // Assert
+            Assert.Equal(script, correctScript);
+        }
+        
+        [Fact]
+        public void BuildVersionCheckScriptPart_WhenTerminationFalse_ShouldNotGoToEnd()
+        {
+            // Arrange
+            var correctScript = @"${If} ${IsWin7}
+!define MB_OK 0x00000000
+!define MB_ICONERROR 0x00000010
+System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+${EndIf}
+";
+            var osValidation = CreateOsValidation();
+            osValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._7));
+            osValidation.TerminateInstallation = false;
+
+            // Act
+            var script = osValidation.BuildVersionCheckScriptPart();
+
+            // Assert
+            Assert.Equal(script, correctScript);
+        }
+        
+        [Fact]
+        public void BuildVersionCheckScriptPart_WhenCustomErrorMessage_ShouldApplyIt()
+        {
+            // Arrange
+            var customErrorMessage = "Custom error message";
+            var correctScript = @"${If} ${IsWin7}
+!define MB_OK 0x00000000
+!define MB_ICONERROR 0x00000010
+System::Call 'USER32::MessageBox(i $hwndparent, t """+customErrorMessage+@""", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+goto end
+${EndIf}
+";
+            var osValidation = CreateOsValidation();
+            osValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._7));
+            osValidation.ErrorMessage = customErrorMessage;
+
+            // Act
+            var script = osValidation.BuildVersionCheckScriptPart();
+
+            // Assert
+            Assert.Equal(script, correctScript);
+        }
+
+        private OSValidation CreateOsValidation() => new OSValidation();
+    }
+}

--- a/Source/src/WixSharp.Test/OSValidationTests.cs
+++ b/Source/src/WixSharp.Test/OSValidationTests.cs
@@ -24,10 +24,14 @@ namespace WixSharp.Test
         {
             // Arrange
             var correctScript = @"${If} ${IsWin7}
-!define MB_OK 0x00000000
-!define MB_ICONERROR 0x00000010
-System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
-goto end
+    ClearErrors
+    ${GetOptions} $R0 ""/S"" $0
+    ${If} ${Errors}
+        !define MB_OK 0x00000000
+        !define MB_ICONERROR 0x00000010
+        System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+    ${EndIf}
+    goto end
 ${EndIf}
 ";
             var osValidation = CreateOsValidation();
@@ -45,11 +49,15 @@ ${EndIf}
         {
             // Arrange
             var correctScript = @"${If} ${IsWin8}
-${AndIf} ${IsServicePack} 1
-!define MB_OK 0x00000000
-!define MB_ICONERROR 0x00000010
-System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
-goto end
+    ${AndIf} ${IsServicePack} 1
+    ClearErrors
+    ${GetOptions} $R0 ""/S"" $0
+    ${If} ${Errors}
+        !define MB_OK 0x00000000
+        !define MB_ICONERROR 0x00000010
+        System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+    ${EndIf}
+    goto end
 ${EndIf}
 ";
             var osValidation = CreateOsValidation();
@@ -67,10 +75,14 @@ ${EndIf}
         {
             // Arrange
             var correctScript = @"${Unless} ${AtLeastWin2012}
-!define MB_OK 0x00000000
-!define MB_ICONERROR 0x00000010
-System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
-goto end
+    ClearErrors
+    ${GetOptions} $R0 ""/S"" $0
+    ${If} ${Errors}
+        !define MB_OK 0x00000000
+        !define MB_ICONERROR 0x00000010
+        System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+    ${EndIf}
+    goto end
 ${EndUnless}
 ";
             var osValidation = CreateOsValidation(); 
@@ -90,11 +102,15 @@ ${EndUnless}
             var correctScript = @"${Unless} ${AtLeastWin7}
 ${OrIf} ${IsWin8}
 ${OrIf} ${IsWin2008}
-${AndIf} ${IsServicePack} 0
-!define MB_OK 0x00000000
-!define MB_ICONERROR 0x00000010
-System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
-goto end
+    ${AndIf} ${IsServicePack} 0
+    ClearErrors
+    ${GetOptions} $R0 ""/S"" $0
+    ${If} ${Errors}
+        !define MB_OK 0x00000000
+        !define MB_ICONERROR 0x00000010
+        System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+    ${EndIf}
+    goto end
 ${EndUnless}
 ";
             var osValidation = CreateOsValidation();
@@ -114,9 +130,13 @@ ${EndUnless}
         {
             // Arrange
             var correctScript = @"${If} ${IsWin7}
-!define MB_OK 0x00000000
-!define MB_ICONERROR 0x00000010
-System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+    ClearErrors
+    ${GetOptions} $R0 ""/S"" $0
+    ${If} ${Errors}
+        !define MB_OK 0x00000000
+        !define MB_ICONERROR 0x00000010
+        System::Call 'USER32::MessageBox(i $hwndparent, t ""This operating system is not supported.$\nPlease, update your OS."", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+    ${EndIf}
 ${EndIf}
 ";
             var osValidation = CreateOsValidation();
@@ -136,10 +156,14 @@ ${EndIf}
             // Arrange
             var customErrorMessage = "Custom error message";
             var correctScript = @"${If} ${IsWin7}
-!define MB_OK 0x00000000
-!define MB_ICONERROR 0x00000010
-System::Call 'USER32::MessageBox(i $hwndparent, t """+customErrorMessage+@""", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
-goto end
+    ClearErrors
+    ${GetOptions} $R0 ""/S"" $0
+    ${If} ${Errors}
+        !define MB_OK 0x00000000
+        !define MB_ICONERROR 0x00000010
+        System::Call 'USER32::MessageBox(i $hwndparent, t """+customErrorMessage+@""", t ""Error"", i ${MB_OK}|${MB_ICONERROR})i'
+    ${EndIf}
+    goto end
 ${EndIf}
 ";
             var osValidation = CreateOsValidation();

--- a/Source/src/WixSharp.Test/WixSharp.Test.csproj
+++ b/Source/src/WixSharp.Test/WixSharp.Test.csproj
@@ -75,6 +75,7 @@
     <Compile Include="IssueFixesTest.cs" />
     <Compile Include="ManagedActionsTest.cs" />
     <Compile Include="ManagedProjectTest.cs" />
+    <Compile Include="OSValidationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegFileTest.cs" />
     <Compile Include="SamplesTest.cs" />

--- a/Source/src/WixSharp/Extensions.cs
+++ b/Source/src/WixSharp/Extensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Diagnostics;
 using System.Drawing;
@@ -2912,6 +2913,34 @@ namespace WixSharp
         public static WixObject ToWObject<T>(this IEnumerable<T> items) where T : WixObject
         {
             return new WixItems(items.Cast<WixObject>());
+        }
+        
+        /// <summary>
+        /// Gets a value of Description attribute from enum
+        /// </summary>
+        /// <param name="value">Enum value</param>
+        /// <returns>Value of Description attribute or default</returns>
+        public static string GetDescription(this Enum value)
+        {
+            var description = GetAttribute<DescriptionAttribute>(value);
+            return description?.Description;
+        }
+        
+        /// <summary>
+        /// Gets an attribute from Enum value
+        /// </summary>
+        /// <param name="value">Enum value</param>
+        /// <typeparam name="TAttribute">Attribute type</typeparam>
+        /// <returns>Instance of specified attribute type or default</returns>
+        public static TAttribute GetAttribute<TAttribute>(this Enum value)
+            where TAttribute : Attribute
+        {
+            var type = value.GetType();
+            var name = Enum.GetName(type, value);
+            return type.GetField(name)
+                .GetCustomAttributes(false)
+                .OfType<TAttribute>()
+                .SingleOrDefault();
         }
     }
 

--- a/Source/src/WixSharp/Nsis/NsisBootstrapper.cs
+++ b/Source/src/WixSharp/Nsis/NsisBootstrapper.cs
@@ -124,6 +124,8 @@ namespace WixSharp.Nsis
         /// If any version added, checks if current windows version is not supported.
         /// <para></para>
         /// If so - displays error and terminates installation (configurable via <see cref="OSValidation"/> properties).
+        /// <para></para>
+        /// If /S switch is added when launching bootstrapped executable - no messagebox will be shown.
         /// </summary>
         // ReSharper disable once InconsistentNaming
         public OSValidation OSValidation { get; } = new OSValidation();
@@ -197,18 +199,17 @@ namespace WixSharp.Nsis
                 AddVersionInformation(writer);
 
                 writer.WriteLine("Function .onInit");
-                
-                var versionCheckScript = OSValidation.BuildVersionCheckScriptPart();
-                if (!string.IsNullOrEmpty(versionCheckScript))
-                {
-                    writer.Write(versionCheckScript);
-                }
-
                 writer.WriteLine("InitPluginsDir");
 
                 // Read command line parameters
                 writer.WriteLine("${GetParameters} $R0");
 
+                var versionCheckScript = OSValidation.BuildVersionCheckScriptPart();
+                if (!string.IsNullOrEmpty(versionCheckScript))
+                {
+                    writer.Write(versionCheckScript);
+                }
+                
                 AddSplashScreen(writer);
 
                 AddPrerequisiteFile(writer, regRootKey, regSubKey, regValueName);

--- a/Source/src/WixSharp/Nsis/NsisBootstrapper.cs
+++ b/Source/src/WixSharp/Nsis/NsisBootstrapper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using WixSharp.CommonTasks;
+using WixSharp.Nsis.WinVer;
 using IO = System.IO;
 using Reflection = System.Reflection;
 
@@ -115,7 +116,17 @@ namespace WixSharp.Nsis
         /// <summary>
         /// Gets or sets digital signature parameters for the bootstrapper.
         /// </summary>
-        public DigitalSignature DigitalSignature;
+        public DigitalSignature DigitalSignature { get; set; }
+
+        /// <summary>
+        /// Allows to validate Windows version
+        /// <para></para>
+        /// If any version added, checks if current windows version is not supported.
+        /// <para></para>
+        /// If so - displays error and terminates installation (configurable via <see cref="OSValidation"/> properties).
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        public OSValidation OSValidation { get; } = new OSValidation();
 
         /// <summary>
         /// Builds bootstrapper file.
@@ -168,6 +179,7 @@ namespace WixSharp.Nsis
             using (var writer = new IO.StringWriter(builder))
             {
                 writer.WriteLine("Unicode true");
+                writer.WriteLine("ManifestSupportedOS all");
 
                 AddIncludes(writer);
 
@@ -185,6 +197,12 @@ namespace WixSharp.Nsis
                 AddVersionInformation(writer);
 
                 writer.WriteLine("Function .onInit");
+                
+                var versionCheckScript = OSValidation.BuildVersionCheckScriptPart();
+                if (!string.IsNullOrEmpty(versionCheckScript))
+                {
+                    writer.Write(versionCheckScript);
+                }
 
                 writer.WriteLine("InitPluginsDir");
 
@@ -230,11 +248,16 @@ namespace WixSharp.Nsis
             return OutputFile;
         }
 
-        private static void AddIncludes(IO.StringWriter writer)
+        private void AddIncludes(IO.StringWriter writer)
         {
             writer.WriteLine("!include LogicLib.nsh");
             writer.WriteLine("!include x64.nsh");
             writer.WriteLine("!include FileFunc.nsh");
+            
+            if (OSValidation.Any)
+            {
+                writer.WriteLine("!include WinVer.nsh");
+            }
         }
 
         private static void AddMacros(IO.StringWriter writer)

--- a/Source/src/WixSharp/Nsis/WinVer/OSValidation.cs
+++ b/Source/src/WixSharp/Nsis/WinVer/OSValidation.cs
@@ -1,0 +1,142 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace WixSharp.Nsis.WinVer
+{
+    /// <summary>
+    /// Adds to Nsis bootstrapper a block of code that compares current windows version with a set of specified versions.
+    /// If version is not supported, shows an error MessageBox with a specified or default <see cref="ErrorMessage"/>.
+    /// Also, can <see cref="TerminateInstallation"/> after showing error message (default = true).
+    /// <example>
+    /// <code>
+    /// bootstrapper.OSValidation.MinVersion = WindowsVersionNumber._7;
+    /// bootstrapper.OSValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._7, 0));
+    /// bootstrapper.OSValidation.UnsupportedVersions.Add(new WindowsVersion(WindowsVersionNumber._8));
+    /// </code>
+    /// </example>
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public class OSValidation
+    {
+        private const string DefaultErrorText = "This operating system is not supported.$\\nPlease, update your OS.";
+
+        /// <summary>
+        ///     Initializes a new instance of NotSupportedWindowsVersions
+        /// </summary>
+        internal OSValidation()
+        {
+        }
+
+        /// <summary>
+        /// Specifies an error message that is shown when OS is not supported
+        /// <para></para>
+        /// If not set, the following error message is shown:
+        /// <para></para>
+        /// This operating system is not supported.$\\nPlease, update your OS.
+        /// </summary>
+        public string ErrorMessage { get; set; } = DefaultErrorText;
+
+        /// <summary>
+        /// Terminate installation if current OS version is not supported. Default = true
+        /// </summary>
+        public bool TerminateInstallation { get; set; } = true;
+
+        /// <summary>
+        /// Minimal required windows version
+        /// </summary>
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once UnusedAutoPropertyAccessor.Global
+        public WindowsVersionNumber? MinVersion { get; set; }
+
+        /// <summary>
+        /// Optional windows versions that are not supported
+        /// </summary>
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once CollectionNeverUpdated.Global
+        public IList<WindowsVersion> UnsupportedVersions { get; } = new List<WindowsVersion>();
+
+        internal bool Any => MinVersion.HasValue || UnsupportedVersions.Any();
+
+        internal string BuildVersionCheckScriptPart()
+        {
+            if (!Any)
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder();
+            using (var writer = new StringWriter(sb))
+            {
+                ConstructScript(writer);
+                return writer.ToString();
+            }
+        }
+
+        private void ConstructScript(StringWriter writer)
+        {
+            WriteMinVersion(writer);
+
+            WriteUnsupportedVersions(writer);
+
+            WriteMessageBox(writer);
+
+            if (TerminateInstallation)
+            {
+                writer.WriteLine("goto end");
+            }
+
+            writer.WriteLine(MinVersion.HasValue ? "${EndUnless}" : "${EndIf}");
+        }
+
+        private void WriteMinVersion(StringWriter writer)
+        {
+            if (!MinVersion.HasValue)
+            {
+                writer.Write("${If} ");
+                return;
+            }
+
+            writer.Write("${Unless} ${AtLeastWin");
+            var minVersion = MinVersion.Value;
+            writer.WriteLine($"{minVersion.GetDescription()}}}");
+
+            if (UnsupportedVersions.Any())
+            {
+                writer.Write("${OrIf} ");
+            }
+        }
+
+        private void WriteUnsupportedVersions(StringWriter writer)
+        {
+            for (var i = 0; i < UnsupportedVersions.Count; i++)
+            {
+                if (i > 0)
+                {
+                    writer.Write("${OrIf} ");
+                }
+
+                var unsupportedVersion = UnsupportedVersions[i];
+
+                writer.Write("${IsWin");
+
+                string winVersion = unsupportedVersion.VersionNumber.GetDescription();
+                writer.WriteLine($"{winVersion}}}");
+
+                if (unsupportedVersion.ServicePack != -1)
+                {
+                    writer.WriteLine($"${{AndIf}} ${{IsServicePack}} {unsupportedVersion.ServicePack}");
+                }
+            }
+        }
+
+        private void WriteMessageBox(StringWriter writer)
+        {
+            writer.WriteLine("!define MB_OK 0x00000000");
+            writer.WriteLine("!define MB_ICONERROR 0x00000010");
+            writer.WriteLine(
+                $"System::Call 'USER32::MessageBox(i $hwndparent, t \"{ErrorMessage}\", t \"Error\", i ${{MB_OK}}|${{MB_ICONERROR}})i'");
+        }
+    }
+}

--- a/Source/src/WixSharp/Nsis/WinVer/WindowsVersion.cs
+++ b/Source/src/WixSharp/Nsis/WinVer/WindowsVersion.cs
@@ -1,0 +1,29 @@
+﻿namespace WixSharp.Nsis.WinVer
+{
+    /// <summary>
+    /// Represents Windows Version
+    /// </summary>
+    public struct WindowsVersion
+    {
+        /// <summary>
+        /// Creates an instance of WindowsVersion struct
+        /// </summary>
+        /// <param name="versionNumber">Represents a windows version</param>
+        /// <param name="servicePack">Represents an optional service pack (-1 = no service pack)</param>
+        public WindowsVersion(WindowsVersionNumber versionNumber, int servicePack = -1)
+        {
+            VersionNumber = versionNumber;
+            ServicePack = servicePack;
+        }
+
+        /// <summary>
+        /// Version to check
+        /// </summary>
+        public WindowsVersionNumber VersionNumber { get; }
+
+        /// <summary>
+        /// Service pack
+        /// </summary>
+        public int ServicePack { get; }
+    }
+}

--- a/Source/src/WixSharp/Nsis/WinVer/WindowsVersionNumber.cs
+++ b/Source/src/WixSharp/Nsis/WinVer/WindowsVersionNumber.cs
@@ -1,0 +1,107 @@
+﻿using System.ComponentModel;
+// ReSharper disable InconsistentNaming
+
+namespace WixSharp.Nsis.WinVer
+{
+    /// <summary>
+    /// Provides a windows version that can be used with AtLeastWin/IsWin/AtMostWin NSIS WinVer operators
+    /// </summary>
+    public enum WindowsVersionNumber
+    {
+        /// <summary>
+        /// Represents Windows 95
+        /// </summary>
+        [Description("95")]
+        _95,
+        
+        /// <summary>
+        /// Represents Windows 98
+        /// </summary>
+        [Description("98")]
+        _98,
+        
+        /// <summary>
+        /// Represents Windows ME
+        /// </summary>
+        [Description("ME")]
+        ME,
+        
+        /// <summary>
+        /// Represents Windows NT4
+        /// </summary>
+        [Description("NT4")]
+        NT4,
+        
+        /// <summary>
+        /// Represents Windows 2000
+        /// </summary>
+        [Description("2000")]
+        _2000,
+        
+        /// <summary>
+        /// Represents Windows XP
+        /// </summary>
+        [Description("XP")]
+        XP,
+        
+        /// <summary>
+        /// Represents Windows 2003
+        /// </summary>
+        [Description("2003")]
+        _2003,
+        
+        /// <summary>
+        /// Represents Windows Vista
+        /// </summary>
+        [Description("Vista")]
+        Vista,
+        
+        /// <summary>
+        /// Represents Windows 2008
+        /// </summary>
+        [Description("2008")]
+        _2008,
+        
+        /// <summary>
+        /// Represents Windows 7
+        /// </summary>
+        [Description("7")]
+        _7,
+        
+        /// <summary>
+        /// Represents Windows 2008R2
+        /// </summary>
+        [Description("2008R2")]
+        _2008R2,
+        
+        /// <summary>
+        /// Represents Windows 8
+        /// </summary>
+        [Description("8")]
+        _8,
+        
+        /// <summary>
+        /// Represents Windows 2012
+        /// </summary>
+        [Description("2012")]
+        _2012,
+        
+        /// <summary>
+        /// Represents Windows 8.1
+        /// </summary>
+        [Description("8.1")]
+        _8_1,
+        
+        /// <summary>
+        /// Represents Windows 2012R2
+        /// </summary>
+        [Description("2012R2")]
+        _2012R2,
+        
+        /// <summary>
+        /// Represents Windows 10
+        /// </summary>
+        [Description("10")]
+        _10
+    }
+}

--- a/Source/src/WixSharp/WixSharp.csproj
+++ b/Source/src/WixSharp/WixSharp.csproj
@@ -153,6 +153,9 @@
     <Compile Include="Nsis\RequestExecutionLevel.cs" />
     <Compile Include="Nsis\SplashScreen.cs" />
     <Compile Include="Nsis\VersionInformation.cs" />
+    <Compile Include="Nsis\WinVer\WindowsVersion.cs" />
+    <Compile Include="Nsis\WinVer\WindowsVersionNumber.cs" />
+    <Compile Include="Nsis\WinVer\OSValidation.cs" />
     <Compile Include="ODBCDataSource.cs" />
     <Compile Include="PermissionEx.cs" />
     <Compile Include="Permissions.cs" />


### PR DESCRIPTION
Currently, NSIS API inside WIX# doesn't support functionality to validate windows versions.
This PR solves that problem by allowing user to specify not supported versions while constructing NSIS bootstrapper.
When NSIS bootstrapper has at least one not supported windows version added, it adds code to the script that checks current windows version.

If NSIS script detects that current windows version is not supported - it:

- Shows an error MessageBox (error text is configurable, also we can omit MessageBox by passing /S switch to the bootstrapped application - support for silent install)  
- Terminates bootstrapper execution after messagebox (by default, this can be disabled via property inside OSValidation class)

This PR includes several unit tests as well as samples that show how to use new functionality.