### PR TITLE
Respect TargetFileName on OverwriteOnInstall option

### DIFF
--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -1710,9 +1710,13 @@ namespace WixSharp
 
                 if (wFile.OverwriteOnInstall)
                 {
+                    string removeFileName = wFile.TargetFileName.IsNotEmpty() ?
+                                            wFile.TargetFileName :
+                                            wFile.Name.PathGetFileName();
+
                     comp.AddElement("RemoveFile",
                                   $@"Id=Remove_{fileId};
-                                     Name={ wFile.Name.PathGetFileName()};
+                                     Name={ removeFileName };
                                      On=both");
                 }
 


### PR DESCRIPTION
If `TargetFileName` is set, it make more sense to create `RemoveFile` element with the TargetFileName.