### PR TITLE
Add support for WixStandardBootstrapperApplication.HyperlinkSidebarLicense

### DIFF
--- a/Source/src/WixSharp/Bootstrapper/BootstrapperApplication.cs
+++ b/Source/src/WixSharp/Bootstrapper/BootstrapperApplication.cs
@@ -479,7 +479,14 @@ namespace WixSharp.Bootstrapper
             }
             else
             {
-                root.SetAttribute("Id", "WixStandardBootstrapperApplication.HyperlinkLicense");
+                if (LogoSideFile.IsEmpty())
+                {
+                    root.SetAttribute("Id", "WixStandardBootstrapperApplication.HyperlinkLicense");
+                }
+                else
+                {
+                    root.SetAttribute("Id", "WixStandardBootstrapperApplication.HyperlinkSidebarLicense");
+                }
 
                 if (LicensePath.IsEmpty())
                 {


### PR DESCRIPTION
This PR is related to [this issue](https://github.com/oleg-shilo/wixsharp/issues/1006).