### PR TITLE
Added the hash of a directory name to the end of the directory Id.

### DIFF
--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -3428,7 +3428,7 @@ namespace WixSharp
                 }
                 else
                 {
-                    wDir.Id = parent.Attribute("Id").Value + "." + wDir.Name.Expand(doNotFixStartDigit: true);
+                    wDir.Id = $"{parent.Attribute("Id").Value}.{wDir.Name.Expand(doNotFixStartDigit: true)}_{(uint)wDir.Name.GetHashCode32()}";
                 }
             }
 


### PR DESCRIPTION
 This prevents a bug that the directory Ids are duplicated if the directory names consists of characters escaped by EscapeIllegalCharacters(), and the lengths are same.