### PR TITLE
Fix BuildMsiCmd generating incorrect custom action dll

### DIFF
--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -546,7 +546,6 @@ namespace WixSharp
         /// <returns>Path to the batch file.</returns>
         static public string BuildMsiCmd(Project project, string path)
         {
-            ClientAssembly = System.Reflection.Assembly.GetCallingAssembly().GetLocation();
             BuildCmd(project, path, OutputType.MSI);
             return path;
         }


### PR DESCRIPTION
BuildMsiCmd was setting Compiler.ClientAssembly to the calling assembly
(i.e.  WixSharp.dll).

This was causing %this%.CA.dll to be generated without any of the custom
actions defined by the project, which is somehow not noticed by WiX and
causes the installer to fail at runtime.

In all other cases, Compiler.ClientAssembly defaults to
`Compiler.FindClientAssemblyInCallStack`, which finds the project exe
that most likely contains the custom action implementations. This
initialisation is done later in BuildWsx, so BuildMsiCmd is fixed by
simply not setting ClientAssembly.