### PR TITLE
fix: service installers possible null reference

### DIFF
--- a/Source/src/WixSharp/File.cs
+++ b/Source/src/WixSharp/File.cs
@@ -176,7 +176,16 @@ namespace WixSharp
         public IGenericEntity ServiceInstaller
         {
             get => ServiceInstallers?.FirstOrDefault();
-            set => ServiceInstallers = new[] { value };
+            set
+            {
+                if (value != null)
+                {
+                    ServiceInstallers = new[]
+                    {
+                        value
+                    };
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes a small issue where the ServiceInstallers property could be initialized with null.

Closes #1190 

EDIT: I see the tests are failing, will fix this later today.