### PR TITLE
skip msi authoring flag

### DIFF
--- a/Source/NuGet/WixSharp/build/WixSharp.targets
+++ b/Source/NuGet/WixSharp/build/WixSharp.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="MSIAuthoring" AfterTargets="AfterBuild">
+  <Target Name="MSIAuthoring" AfterTargets="AfterBuild" Condition="'$(SkipMSIAuthoring)' != 'true'">
     <Message Importance="high" Text="Building MSI" />
     <Exec Command="&quot;$(TargetPath)&quot; &quot;/MSBUILD:$(ProjectName)&quot; &quot;/WIXBIN:$(WixBinPackage)&quot; &quot;/Configuration:$(Configuration)&quot; &quot;/Platform:$(Platform)&quot;" WorkingDirectory="$(ProjectDir)"/>
   </Target>


### PR DESCRIPTION
There is an additional flag in .targets, `SkipMSIAuthoring`, if it is set, the command is never executed, XML is never assembled and MSI is never built.
It is useful for creation of own libraries of classes inherited from classes of WixSharp namespace.

There are few lines I would suggest to have added to WixSharp wiki [here](https://github.com/oleg-shilo/wixsharp/wiki/Developer's-Guide#building-msi-file) after _The actual building of the .msi file will be triggered by ..._ paragraph:

```
To prevent MSI authoring, it is necessary to add to the project properties:

<PropertyGroup>
    <SkipMSIAuthoring>true</SkipMSIAuthoring>
</PropertyGroup>
```
