### PR TITLE
Add #error to custom UI template reminding people to replace the GUID

### DIFF
--- a/Source/Templates/ProjectTemplates/WixSharp Managed Setup - Cusom UI/Program.cs
+++ b/Source/Templates/ProjectTemplates/WixSharp Managed Setup - Cusom UI/Program.cs
@@ -16,6 +16,7 @@ namespace $safeprojectname$
                              new Dir(@"%ProgramFiles%\My Company\My Product",
                                  new File("Program.cs")));
 
+            #error "DON'T FORGET to replace this with a freshly generated GUID and remove this `#error` statement."
             project.GUID = new Guid("6fe30b47-2577-43ad-9095-1861ba25889b");
 
             //custom set of standard UI dialogs


### PR DESCRIPTION
There's a few google results for this GUID that probably shouldn't be using this GUID :)

I used `#error` based on line 5