### PR TITLE
Fix error WIX0400: The ProgressText element contains illegal inner te…

### DIFF
--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -2737,13 +2737,13 @@ namespace WixSharp
                 if (wAction.ProgressText.IsNotEmpty())
                 {
                     uis.ForEach(ui =>
-                        ui.Add(new XElement("ProgressText", wAction.ProgressText,
+                        ui.Add(new XElement("ProgressText", new XAttribute("Value", wAction.ProgressText),
                             new XAttribute("Action", wAction.Id))));
                 }
                 if (wAction.RollbackProgressText != null)
                 {
                     uis.ForEach(ui =>
-                        ui.Add(new XElement("ProgressText", wAction.RollbackProgressText,
+                        ui.Add(new XElement("ProgressText",  new XAttribute("Value", wAction.RollbackProgressText),
                             new XAttribute("Action", roollbackActionId))));
                 }
 


### PR DESCRIPTION
…xt when setting CustomAction ProgressText or RollbackProgressText with wixsharp the created wcs file looks like 
<ProgressText Action="ExtractZip">[UIExpandArchiveProgress]</ProgressText> but in wix4 inner text is not allowed.
This tiny fix creates the xml like
<ProgressText Action="ExtractZip">Value="[UIExpandArchiveProgress]"</ProgressText>.