### PR TITLE
Reduce number of lost logging messages in failure conditions

### DIFF
--- a/Source/src/WixSharp.UI/ManagedUI/MsiSessionAdapter.cs
+++ b/Source/src/WixSharp.UI/ManagedUI/MsiSessionAdapter.cs
@@ -156,8 +156,54 @@ namespace WixSharp
         /// <param name="msg">The line to be written to the log</param>
         public void Log(string msg)
         {
-            MsiSession.Log(msg);
-            InstallerRuntime.VirtualLog.AppendLine(msg);
+            //
+            // The call to MSI session can fail, making the second logging disappear.
+            // However, especially logging can be very helpful when analyzing an
+            // issue. When part of the logging system does not work, it reduces
+            // analysis time when other parts are still fed with relevant messages.
+            //
+            List<Exception> exceptions = new List<Exception>();
+
+            try
+            {
+                try
+                {
+                    MsiSession.Log(msg);
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+
+                try
+                {
+                    InstallerRuntime.VirtualLog.AppendLine(msg);
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+            finally
+            {
+                if (exceptions.Count > 0)
+                {
+                    Exception ex;
+
+                    if (exceptions.Count == 1)
+                    {
+                        ex = exceptions[0];
+                    }
+                    else
+                    {
+                        ex = new AggregateException(exceptions);
+                    }
+
+                    ex.Data.Add($"{nameof(Log)}-msg", msg);
+
+                    throw ex;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
During analysis of a problem with a build, it occurred to me that when the first log destination fails, the virtual log (whatever that is) is neither fed with the log message.

This behaviour hinders analysis.

This patch improves logging capabilities, even when part of the log system is broken / generates an error.

```
{"itgenmsi151","Message":"** Info: === Logging started: 14-12-2024  14:32:14 ==="
{"itgenmsi501","Message":"First chance exception handling of type 'InstallerException':"
{"itgenmsi502","Message":"Exception of type 'Microsoft.Deployment.WindowsInstaller.InstallerException' was thrown. (type: InstallerException)"
{"itgenmsj681","Message":"No exception data to register."
{"itgenmsi504","Message":"Stack trace:"
{"itgenmsi505","Message":"   at System.Environment.GetStackTrace(Exception e, Boolean needFileInfo)"
{"itgenmsi505","Message":"   at System.Environment.get_StackTrace()"
{"itgenmsi505","Message":"   at Acme.Deploy.Error.CurrentDomain_FirstChanceException(Object sender, FirstChanceExceptionEventArgs e)"
{"itgenmsi505","Message":"   at Microsoft.Deployment.WindowsInstaller.Session.Message(InstallMessage messageType, Record record)"
{"itgenmsi505","Message":"   at Microsoft.Deployment.WindowsInstaller.Session.Log(String msg)"
{"itgenmsi505","Message":"   at WixSharp.MsiSessionAdapter.Log(String msg)"
{"itgenmsi505","Message":"   at Acme.Deploy.Runtime.LogUtility.LogToSession(SessionState sessionState, String txt)"
{"itgenmsi505","Message":"   at Acme.Deploy.Runtime.LogUtility.LogToSession(SessionState sessionState, TraceContext traceContext)"
{"itgenmsi505","Message":"   at Acme.Deploy.Runtime.LogUtility.LogLine(SessionState sessionState, String txt, String messageCode)"
{"itgenmsi505","Message":"   at Acme.Deploy.Runtime.LogUtility.LogLines(SessionState sessionState, String linePrefix, String[] lines, String messageCode)"
{"itgenmsi505","Message":"   at Acme.Deploy.UI.ProgressDialog.ProcessMessage(InstallMessage messageType, Record messageRecord, MessageButtons buttons, MessageIcon icon, MessageDefaultButton defaultButton)"
{"itgenmsi505","Message":"   at WixSharp.UIShell.<>c__DisplayClass69_0.<ProcessMessage>b__1()"
{"itgenmsi505","Message":"   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)"
{"itgenmsi505","Message":"   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)"
```