### PR TITLE
Add "unspecified" store type to allow third-party tool AzureSignTool

### DIFF
--- a/Source/src/WixSharp/CommonTasks.cs
+++ b/Source/src/WixSharp/CommonTasks.cs
@@ -205,19 +205,24 @@ namespace WixSharp.CommonTasks
             bool shouldSignSHA1 = (hashAlgorithm & HashAlgorithmType.sha1) == HashAlgorithmType.sha1;
             bool shouldSignSHA256 = (hashAlgorithm & HashAlgorithmType.sha256) == HashAlgorithmType.sha256;
 
-            string certPlace;
+            string certOption;
             switch (certificateStore)
             {
                 case StoreType.commonName:
-                    certPlace = "/n";
+                    certOption = "/n";
                     break;
 
                 case StoreType.sha1Hash:
-                    certPlace = "/sha1";
+                    certOption = "/sha1";
                     break;
 
+                case StoreType.file:
+                    certOption = "/f";
+                    break;
+
+                case StoreType.unspecified:
                 default:
-                    certPlace = "/f";
+                    certOption = string.Empty;
                     break;
             }
 
@@ -240,7 +245,9 @@ namespace WixSharp.CommonTasks
                     break;
             }
 
-            string args = $"sign {outputLevelArg}{certPlace} \"{certificateId}\"";
+            string certPart = certOption.IsEmpty() ? string.Empty : $"{certOption} \"{certificateId}\"";
+
+            string args = $"sign {outputLevelArg}{certPart}";
             if (password.IsNotEmpty())
                 args += $" /p \"{password}\"";
 

--- a/Source/src/WixSharp/Enums.cs
+++ b/Source/src/WixSharp/Enums.cs
@@ -450,7 +450,8 @@ namespace WixSharp
     {
         file,
         commonName,
-        sha1Hash
+        sha1Hash,
+        unspecified
     }
 
     [Flags]


### PR DESCRIPTION
AzureSignTool is a handy community-made (and Microsoft supported) tool allowing remote certificates to be used to sign files. It is designed to be an easy "drop-in" replacement since it follows the same option naming scheme than SignTool.
https://github.com/vcsjones/AzureSignTool

Problem is the following: it doesn't have the `/f` option to specify the certificate file since this latter is remotely stored in a secure Azure Key Vault. Options to get it are `-kvi`, `-kvt`, `-kvs` and `-kvc` which can be supplied in `DigitalSignature`'s existing `OptionalArguments`.

This PR simply adds an `unspecified` value to the `StoreType` enum and skips the command-line argument when relevant.