### PR TITLE
Typo: wrong port number in example code

### DIFF
--- a/Source/src/WixSharp/WebSite.cs
+++ b/Source/src/WixSharp/WebSite.cs
@@ -212,7 +212,7 @@ namespace WixSharp
         ///         new WebSite.WebAddress
         ///         {
         ///             Address = "*",
-        ///             Port = 80
+        ///             Port = 90
         ///         }
         ///     }
         /// </code>


### PR DESCRIPTION
The example has `webSite.AddressesDefinition = "*:80;*90";`, but the subsequent equivalent addresses have both ports as 80