### PR TITLE
DirectorySearch was missing from the csproj compile itemgroup

### DIFF
--- a/Source/src/NET-Core/WixSharp.Core/WixSharp.Core.csproj
+++ b/Source/src/NET-Core/WixSharp.Core/WixSharp.Core.csproj
@@ -93,6 +93,7 @@
         <Compile Include="..\..\WixSharp\DigitalSignature.cs" Link="DigitalSignature.cs" />
         <Compile Include="..\..\WixSharp\DigitalSignatureBootstrapper.cs" Link="DigitalSignatureBootstrapper.cs" />
         <Compile Include="..\..\WixSharp\Dir.cs" Link="Dir.cs" />
+        <Compile Include="..\..\WixSharp\DirectorySearch.cs" Link="DirectorySearch.cs" />
         <Compile Include="..\..\WixSharp\DirectoryShortcut.cs" Link="DirectoryShortcut.cs" />
         <Compile Include="..\..\WixSharp\DirFiles.cs" Link="DirFiles.cs" />
         <Compile Include="..\..\WixSharp\DriverInstaller.cs" Link="DriverInstaller.cs" />

--- a/Source/src/WixSharp/WixSharp.NET451.csproj
+++ b/Source/src/WixSharp/WixSharp.NET451.csproj
@@ -123,6 +123,7 @@
     <Compile Include="CustomActionRef.cs" />
     <Compile Include="DigitalSignature.cs" />
     <Compile Include="DigitalSignatureBootstrapper.cs" />
+    <Compile Include="DirectorySearch.cs" />
     <Compile Include="DirectoryShortcut.cs" />
     <Compile Include="DriverInstaller.cs" />
     <Compile Include="BinaryFileAction.cs" />

--- a/Source/src/WixSharp/WixSharp.csproj
+++ b/Source/src/WixSharp/WixSharp.csproj
@@ -128,6 +128,7 @@
     <Compile Include="CustomActionRef.cs" />
     <Compile Include="DigitalSignature.cs" />
     <Compile Include="DigitalSignatureBootstrapper.cs" />
+    <Compile Include="DirectorySearch.cs" />
     <Compile Include="DirectoryShortcut.cs" />
     <Compile Include="DriverInstaller.cs" />
     <Compile Include="BinaryFileAction.cs" />


### PR DESCRIPTION
The DirectorySearch option was missing from the new release, and I think this is the reason why.

I tried compiling myself, but I don't have the WixSharpStrongName.snk file so it won't complete. I removed signing from the .NET Core csproj and it built without issue but I'm not sure if that's enough to validate this as working or not.
 
I've added it to all three (.NET Core, 4.7.2, and 4.5.1) but please do let me know if that still isn't right.