### PR TITLE
fix serialization of MultiString RegValue

### DIFF
--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -2398,8 +2398,12 @@ namespace WixSharp
 
                     if (regValEl.Attribute("Type").Value == "multiString")
                     {
-                        foreach (string line in stringValue.GetLines())
-                            regValEl.Add(new XElement("MultiStringValue", line));
+                        foreach (string line in stringValue.GetLines()) 
+						{
+							var lineEl = new XElement("MultiStringValue");
+							lineEl.SetAttribute("Value", line);
+                            regValEl.Add(lineEl);
+						}
                     }
                     else
                         regValEl.Add(new XAttribute("Value", stringValue));


### PR DESCRIPTION
This PR fixes #1812.

The serialization of `MultiString` `RegValue` now store the value inside the ´Value´ attribute of the node instead of using the inner text.

