### PR TITLE
Fix null handling for Windows 10 SDK path discovery

### DIFF
--- a/Source/src/WixSharp/Utilities/WixTools.cs
+++ b/Source/src/WixSharp/Utilities/WixTools.cs
@@ -98,8 +98,9 @@ namespace WixSharp.CommonTasks
             //  @"C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x86",
             var win10sdk = Environment.SpecialFolder.ProgramFilesX86.GetPath().PathJoin("Windows Kits", "10", "bin");
             if (!win10sdk.PathExists())
-                win10sdk = ((string)Microsoft.Win32.Registry.GetValue(
-                    @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots", "KitsRoot10", null))
+                win10sdk = (Microsoft.Win32.Registry.GetValue(
+                        @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots", "KitsRoot10",
+                        null) as string)?
                     .PathJoin("bin");
 
             return Directory.Exists(win10sdk)


### PR DESCRIPTION
Updated the logic to safely cast the registry value to string and use null-conditional operator when joining the path. This prevents an ArgumentNullException if PathJoin is called with a null string because the registry key is missing.

fixes a regression caused by #1823 