### PR TITLE
Added the Wix WebAddress 'Header' attribute

### DIFF
--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -2472,6 +2472,10 @@ namespace WixSharp
                                                             new XAttribute("Port", address.Port)));
 
                 xAddress.AddAttributes(address.Attributes);
+
+                if (!string.IsNullOrEmpty(address.Header))
+                    xAddress.SetAttribute("Header", address.Header)
+
             }
 
             if (webSite.Certificate != null)

--- a/Source/src/WixSharp/WebSite.cs
+++ b/Source/src/WixSharp/WebSite.cs
@@ -179,6 +179,11 @@ namespace WixSharp
             public int Port = 0;
 
             /// <summary>
+            /// Sets the host name.
+            /// </summary>
+            public string Header = "";
+
+            /// <summary>
             /// Optional attributes of the <c>WebAddress Element</c> (e.g. Secure:YesNoPath).
             /// </summary>
             /// <example>


### PR DESCRIPTION
Added the missing 'Header' attribute for IIS Web Addresses. This is so users (such as myself) can set host names for IIS Bindings.