### PR TITLE
Feature/fileassociation-iconfile

### DIFF
--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -1679,7 +1679,21 @@ namespace WixSharp
                                                   new XAttribute("Command", wFileAssociation.Command),
                                                   new XAttribute("Argument", wFileAssociation.Arguments)))));
 
-                    if (wFileAssociation.Icon != null)
+                    // Handle icon for file association
+                    // IconFile takes precedence over Icon if both are set
+                    if (wFileAssociation.IconFile.IsNotEmpty())
+                    {
+                        // IconFile is set - auto-register an Icon element and use its ID
+                        var icon = new IconFile { SourceFile = wFileAssociation.IconFile };
+
+                        progId.Parent(Compiler.ProductElementName)
+                              .AddElement(icon.ToXElement("Icon"));
+
+                        progId.Add(
+                            new XAttribute("Icon", icon.Id),
+                            new XAttribute("IconIndex", wFileAssociation.IconIndex));
+                    }
+                    else if (wFileAssociation.Icon != null)
                     {
                         if (wFileAssociation.Advertise)
                         {

--- a/Source/src/WixSharp/FileAssosiation.cs
+++ b/Source/src/WixSharp/FileAssosiation.cs
@@ -121,6 +121,27 @@ namespace WixSharp
         public string Icon = "";
 
         /// <summary>
+        /// Path to an icon file (.ico) to be used for the file association.
+        /// <para>
+        /// When set, WixSharp will automatically register an <c>Icon</c> element and use its ID
+        /// for the file association icon. This simplifies icon setup for non-advertised file associations.
+        /// </para>
+        /// <para>
+        /// If both <see cref="IconFile"/> and <see cref="Icon"/> are set, <see cref="IconFile"/> takes precedence.
+        /// </para>
+        /// </summary>
+        ///<example>The following is an example of using <c>IconFile</c> to set a custom icon for a file association:
+        ///<code>
+        /// new File("MyApp.exe",
+        ///     new FileAssociation("myext", "application/myext", "open", "\"%1\"")
+        ///     {
+        ///         IconFile = "MyIcon.ico"
+        ///     });
+        ///</code>
+        /// </example>
+        public string IconFile = "";
+
+        /// <summary>
         /// The zero-based index of the icon associated with this ProgId. The default value is <c>0</c>.
         /// </summary>
         public int IconIndex = 0;


### PR DESCRIPTION
Added: FileAssociation.IconFile property for auto-registering icon files
    
When IconFile is set to a path, WixSharp automatically registers an Icon element and uses its ID for the file association.
    
This simplifies icon setup for non-advertised file associations where the Icon attribute must be an Icon Id rather than a file path.
