### PR TITLE
Added: InstalledFileAction resolves file key by name if ID not found

### DIFF
--- a/Source/src/WixSharp/Compiler.cs
+++ b/Source/src/WixSharp/Compiler.cs
@@ -2542,6 +2542,45 @@ namespace WixSharp
         }
 
         /// <summary>
+        /// Resolves a file key (ID or name) to the actual file ID.
+        /// First tries to find a file with matching ID, then searches by filename.
+        /// </summary>
+        /// <param name="wProject">The project containing the files.</param>
+        /// <param name="key">The file key (ID or filename) to resolve.</param>
+        /// <returns>The resolved file ID.</returns>
+        /// <exception cref="System.Exception">Thrown when multiple files match the name or no file is found.</exception>
+        static string ResolveFileKey(Project wProject, string key)
+        {
+            string result = key; // Default: return key as-is
+
+            // First, check if any file has this exact ID
+            var fileById = wProject.AllFiles.FirstOrDefault(f => f.Id == key);
+            if (fileById != null)
+            {
+                result = fileById.Id;
+            }
+            else
+            {
+                // If not found by ID, search by filename
+                var matchingFiles = wProject.FindFile(f => f.Name.PathGetFileName().SameAs(key, ignoreCase: true));
+
+                if (matchingFiles.Length > 1)
+                {
+                    throw new Exception($"InstalledFileAction key '{key}' matches multiple files in the project. " +
+                        $"Please use an explicit file ID or ensure unique filenames. " +
+                        $"Matching files: {string.Join(", ", matchingFiles.Select(f => f.Name))}");
+                }
+                else if (matchingFiles.Length == 1)
+                {
+                    result = matchingFiles[0].Id;
+                }
+                // else: no match found - result stays as key (original behavior)
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Processes the custom actions.
         /// </summary>
         /// <param name="wProject">The w project.</param>
@@ -2933,6 +2972,9 @@ namespace WixSharp
                 {
                     var fileAction = (InstalledFileAction)wAction;
 
+                    // Resolve the file key - first tries exact ID match, then searches by filename
+                    var resolvedFileKey = ResolveFileKey(wProject, fileAction.Key);
+
                     sequences.ForEach(sequence =>
                         sequence.Add(
                             new XElement("Custom",
@@ -2944,7 +2986,7 @@ namespace WixSharp
                         new XElement("CustomAction",
                                 new XAttribute("Id", wAction.Id),
                                 new XAttribute("ExeCommand", fileAction.Args.ExpandCommandPath()),
-                                new XAttribute("FileRef", fileAction.Key))
+                                new XAttribute("FileRef", resolvedFileKey))
                             .SetAttribute("Return", wAction.Return)
                             .SetAttribute("Impersonate", wAction.Impersonate)
                             .SetAttribute("Execute", wAction.Execute)
@@ -2952,6 +2994,9 @@ namespace WixSharp
 
                     if ((fileAction.Execute == Execute.deferred) && fileAction.Rollback.IsNotEmpty())
                     {
+                        // Resolve the rollback file key as well
+                        var resolvedRollbackKey = ResolveFileKey(wProject, fileAction.Rollback);
+
                         sequences.ForEach(sequence =>
                             sequence.Add(new XElement("Custom",
                                 new XAttribute("Condition", wActionCondition),
@@ -2964,7 +3009,7 @@ namespace WixSharp
                                     new XAttribute("ExeCommand", fileAction.RollbackArg == null
                                         ? fileAction.Args.ExpandCommandPath()
                                         : fileAction.RollbackArg.ExpandCommandPath()),
-                                    new XAttribute("FileRef", fileAction.Rollback))
+                                    new XAttribute("FileRef", resolvedRollbackKey))
                                 .SetAttribute("Return", wAction.Return)
                                 .SetAttribute("Impersonate", wAction.Impersonate)
                                 .SetAttribute("Execute", Execute.rollback)

--- a/Source/src/WixSharp/InstalledFileAction.cs
+++ b/Source/src/WixSharp/InstalledFileAction.cs
@@ -293,8 +293,26 @@ namespace WixSharp
         }
 
         /// <summary>
-        /// The key (file name) of the installed file to be executed.
+        /// The key (file name or ID) of the installed file to be executed.
+        /// <para>
+        /// If an exact ID match is not found among the project files, WixSharp will search
+        /// for a file with this name (case-insensitive) and use its ID.
+        /// </para>
+        /// <para>
+        /// This allows using simple file names like "MyApp.exe" instead of having to specify
+        /// the exact WiX-generated file ID.
+        /// </para>
         /// </summary>
+        /// <example>
+        /// Both of these work:
+        /// <code>
+        /// // Using filename (WixSharp resolves to actual file ID)
+        /// new InstalledFileAction("MyApp.exe", "--uninstall", ...)
+        ///
+        /// // Using explicit ID (if you set one on the File)
+        /// new InstalledFileAction("MyApp_exe_ID", "--uninstall", ...)
+        /// </code>
+        /// </example>
         public string Key = "";
 
         /// <summary>


### PR DESCRIPTION
When the Key property doesn't match an exact file ID, WixSharp now searches for a file by name (case-insensitive) and uses its ID.

This allows using simple filenames like "MyApp.exe" instead of having to specify the WiX-generated file ID.

If multiple files match the name, an exception is thrown with a clear error message listing the matching files.