### PR TITLE
Fix ArgumentNullException on MemoryStream constructor

### DIFF
--- a/Source/src/WixSharp.UI/ManagedUI/UIShell.cs
+++ b/Source/src/WixSharp.UI/ManagedUI/UIShell.cs
@@ -357,8 +357,12 @@ namespace WixSharp
                         try
                         {
                             var data = Runtime.Session.GetResourceData("ui_shell_icon");
-                            using (var stream = new System.IO.MemoryStream(data))
-                                shellView.Icon = new Icon(stream);
+
+                            if (data != null)
+                            {
+                                using (var stream = new System.IO.MemoryStream(data))
+                                    shellView.Icon = new Icon(stream);
+                            }
                         }
                         catch { }
 


### PR DESCRIPTION
This is a minor fix that prevents `ArgumentNullException`s to be raised when the icon returned from `Runtime.Session.GetResourceData("ui_shell_icon")` is `null` in `UIShell.ShowModal`.