### PR TITLE
Adds display/logging/restart arguments to end of msiexec string when generating self-hosted MSI executable

### DIFF
--- a/Source/src/WixSharp/Utilities/Utils.cs
+++ b/Source/src/WixSharp/Utilities/Utils.cs
@@ -149,6 +149,8 @@ using System.Reflection;
 [assembly: AssemblyFileVersion(""" + version + @""")]
 class Program
 {
+    static readonly string[] beforeArgKeys = { ""/i"", ""/a"", ""/ju"", ""/jm"", ""/j/g"", ""/j/t"", ""/x"" };
+
     static int Main(string[] args)
     {
         // Debug.Assert(false);
@@ -158,9 +160,14 @@ class Program
         try
         {
             ExtractMsi(msi);
-            string msi_args = args.Any() ? string.Join("" "", args) : ""/i"";
+            
+            IEnumerable<string> beforeMsiArgs = args.Where(arg => beforeArgKeys.Contains(arg));
+            IEnumerable<string> afterMsiArgs = args.Except(beforeMsiArgs);
 
-            Process p = Process.Start(""msiexec.exe"", msi_args + "" \"""" + msi + ""\"""");
+            string msi_args = beforeMsiArgs.Any() ? string.Join("" "", beforeMsiArgs) : ""/i"";
+            string msi_args_after = string.Join("" "", afterMsiArgs);
+
+            Process p = Process.Start(""msiexec.exe"", msi_args + "" \"""" + msi + ""\"""" + msi_args_after);
             p.WaitForExit();
             return p.ExitCode;
         }

--- a/Source/src/WixSharp/Utilities/Utils.cs
+++ b/Source/src/WixSharp/Utilities/Utils.cs
@@ -136,6 +136,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Reflection;
+using System.Collections.Generic;
 
 [assembly: AssemblyTitle(""" + outFile.PathGetFileName() + @""")]
 [assembly: AssemblyDescription(""Self-hosted " + outFile.PathGetFileNameWithoutExtension() + @".msi"")]
@@ -160,7 +161,7 @@ class Program
         try
         {
             ExtractMsi(msi);
-            
+
             IEnumerable<string> beforeMsiArgs = args.Where(arg => beforeArgKeys.Contains(arg));
             IEnumerable<string> afterMsiArgs = args.Except(beforeMsiArgs);
 

--- a/Source/src/WixSharp/Utilities/Utils.cs
+++ b/Source/src/WixSharp/Utilities/Utils.cs
@@ -150,7 +150,7 @@ using System.Collections.Generic;
 [assembly: AssemblyFileVersion(""" + version + @""")]
 class Program
 {
-    static readonly string[] beforeArgKeys = { ""/i"", ""/a"", ""/ju"", ""/jm"", ""/j/g"", ""/j/t"", ""/x"" };
+    static readonly string[] beforeArgKeys = { ""/i"", ""/a"", ""/ju"", ""/jm"", ""/j/g"", ""/j/t"", ""/x"", ""/fp"", ""/fo"", ""/fe"", ""/fd"", ""/fc"", ""/fa"", ""/fu"", ""/fm"", ""/fs"", ""/fv"" };
 
     static int Main(string[] args)
     {


### PR DESCRIPTION
This change creates two separate argument arrays for arguments passed to msiexec.exe when creating self-hosted MSI executables via the **CompileSelfHostedMsi** method in the **ExeGen** class. The install arguments are built into the command string before the path to the package and the remaining parameters are added after.

I used the microsoft help page as a refernece [msiexec documentation](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/msiexec).

This should resolve #1941.